### PR TITLE
Fixed type conversion warnings in unit tests

### DIFF
--- a/aspects/electrical/Batt/test/UtGunnsElectBattery.cpp
+++ b/aspects/electrical/Batt/test/UtGunnsElectBattery.cpp
@@ -228,7 +228,7 @@ void UtGunnsElectBattery::testNominalInitialization()
     CPPUNIT_ASSERT(tMalfThermalRunawayFlag     == tArticle->mMalfThermalRunawayFlag);
     CPPUNIT_ASSERT(tMalfThermalRunawayDuration == tArticle->mMalfThermalRunawayDuration);
     CPPUNIT_ASSERT(tMalfThermalRunawayInterval == tArticle->mMalfThermalRunawayInterval);
-    CPPUNIT_ASSERT(tNumCells                   == tArticle->mNumCells);
+    CPPUNIT_ASSERT(tNumCells                   == static_cast<int>(tArticle->mNumCells));
     CPPUNIT_ASSERT(tCellsInParallel            == tArticle->mCellsInParallel);
     CPPUNIT_ASSERT(tInterconnectResistance     == tArticle->mInterconnectResistance);
     CPPUNIT_ASSERT(tSocVocTable                == tArticle->mSocVocTable);
@@ -538,7 +538,7 @@ void UtGunnsElectBattery::testThermalRunaway()
 
     /// @test malfunction restart, results after all cells have finished.
     tArticle->setMalfThermalRunaway(true, 1.0, 1.0);
-    for (unsigned int i=0; i<11*tNumCells; ++i) {
+    for (int i=0; i<11*tNumCells; ++i) {
         tArticle->step(dt);
         tArticle->computeFlows(dt);
     }

--- a/aspects/electrical/Converter/test/UtConverterElect.cpp
+++ b/aspects/electrical/Converter/test/UtConverterElect.cpp
@@ -79,10 +79,10 @@ void UtConverterElect::setUp() {
     tConverterOnConductance            = 200;
     tConverterOffConductance           = 1.0e-6;
     tStandbyPower                      =  105.0;
-    tOutVoltageUpperLimit              =  140.0;
-    tOutCurrentUpperLimit              =  125.0;
-    tOutVoltageNoiseScale              =   2.80;
-    tOutCurrentNoiseScale              =   3.75;
+    tOutVoltageUpperLimit              =  140.0F;
+    tOutCurrentUpperLimit              =  125.0F;
+    tOutVoltageNoiseScale              =   2.80F;
+    tOutCurrentNoiseScale              =   3.75F;
     tTripPriority                      =      3;
 
     // input data
@@ -119,10 +119,10 @@ void UtConverterElect::setUp() {
     tTolerance          = 1.0e-08;
 
     // sensor config data
-    tOutVoltageSensorConfig = new SensorAnalogConfigData(0.0, tOutVoltageUpperLimit, 0.0, 0.0, 1.0, tOutVoltageNoiseScale,
-                                                         0.001, 0, UnitConversion::NO_CONVERSION);
-    tOutCurrentSensorConfig = new SensorAnalogConfigData(-125.0, tOutCurrentUpperLimit, 0.0, 0.0, 1.0, tOutCurrentNoiseScale,
-                                                         0.001, 0, UnitConversion::NO_CONVERSION);
+    tOutVoltageSensorConfig = new SensorAnalogConfigData(0.0F, tOutVoltageUpperLimit, 0.0F, 0.0F, 1.0F, tOutVoltageNoiseScale,
+                                                         0.001F, 0, UnitConversion::NO_CONVERSION);
+    tOutCurrentSensorConfig = new SensorAnalogConfigData(-125.0F, tOutCurrentUpperLimit, 0.0F, 0.0F, 1.0F, tOutCurrentNoiseScale,
+                                                         0.001F, 0, UnitConversion::NO_CONVERSION);
 
     // sensor input data
     tOutVoltageSensorInput  = new SensorAnalogInputData(true, 0.0);

--- a/aspects/electrical/Converter/test/UtConverterSensors.cpp
+++ b/aspects/electrical/Converter/test/UtConverterSensors.cpp
@@ -69,16 +69,16 @@ void UtConverterSensors::setUp() {
     mInOverVoltageTripActive                            = false;
     mInOverVoltageTripActive                            = false;
 
-    mOutVoltageSensorConfig.mMaxRange                   = 250.0;
-    mOutVoltageSensorConfig.mNominalResolution          = 0.01;
-    mOutVoltageSensorConfig.mNominalScale               = 1.0;
-    mOutVoltageSensorConfig.mNominalNoiseScale          = 0.555;
+    mOutVoltageSensorConfig.mMaxRange                   = 250.0F;
+    mOutVoltageSensorConfig.mNominalResolution          = 0.01F;
+    mOutVoltageSensorConfig.mNominalScale               = 1.0F;
+    mOutVoltageSensorConfig.mNominalNoiseScale          = 0.555F;
     mOutVoltageSensorConfig.mNoiseFunction              = TsNoise::getNoise;
 
-    mOutCurrentSensorConfig.mMaxRange                   = 100.0;
-    mOutCurrentSensorConfig.mNominalResolution          = 0.01;
-    mOutCurrentSensorConfig.mNominalScale               = 1.0;
-    mOutCurrentSensorConfig.mNominalNoiseScale          = 0.225;
+    mOutCurrentSensorConfig.mMaxRange                   = 100.0F;
+    mOutCurrentSensorConfig.mNominalResolution          = 0.01F;
+    mOutCurrentSensorConfig.mNominalScale               = 1.0F;
+    mOutCurrentSensorConfig.mNominalNoiseScale          = 0.225F;
     mOutCurrentSensorConfig.mNoiseFunction              = TsNoise::getNoise;
 
     mConfig                 = new ConverterSensorsConfigData(mStandbyPower,

--- a/aspects/electrical/Converter/test/UtGunnsElectConverterInput.cpp
+++ b/aspects/electrical/Converter/test/UtGunnsElectConverterInput.cpp
@@ -83,8 +83,8 @@ void UtGunnsElectConverterInput::setUp()
                                                                  &tSensorVin,
                                                                  &tSensorIin,
                                                                  tTripPriority,
-                                                                 tInUnderVoltageTrip,
-                                                                 tInOverVoltageTrip,
+                                                                 static_cast<float>(tInUnderVoltageTrip),
+                                                                 static_cast<float>(tInOverVoltageTrip),
                                                                  tEfficiencyTable);
 
     /// - Define the nominal input data.
@@ -149,26 +149,26 @@ void UtGunnsElectConverterInput::testConfig()
     CPPUNIT_ASSERT(&tSensorVin         == tConfigData->mInputVoltageSensor);
     CPPUNIT_ASSERT(&tSensorIin         == tConfigData->mInputCurrentSensor);
     CPPUNIT_ASSERT(tTripPriority       == tConfigData->mTripPriority);
-    CPPUNIT_ASSERT(tInUnderVoltageTrip == tConfigData->mInputUnderVoltageTripLimit);
-    CPPUNIT_ASSERT(tInOverVoltageTrip  == tConfigData->mInputOverVoltageTripLimit);
+    CPPUNIT_ASSERT(tInUnderVoltageTrip == static_cast<double>(tConfigData->mInputUnderVoltageTripLimit));
+    CPPUNIT_ASSERT(tInOverVoltageTrip  == static_cast<double>(tConfigData->mInputOverVoltageTripLimit));
     CPPUNIT_ASSERT(tEfficiencyTable    == tConfigData->mEfficiencyTable);
 
     /// @test    Configuration data default construction.
     GunnsElectConverterInputConfigData defaultConfig;
-    CPPUNIT_ASSERT(0   == defaultConfig.mInputVoltageSensor);
-    CPPUNIT_ASSERT(0   == defaultConfig.mInputCurrentSensor);
-    CPPUNIT_ASSERT(0   == defaultConfig.mTripPriority);
-    CPPUNIT_ASSERT(0.0 == defaultConfig.mInputUnderVoltageTripLimit);
-    CPPUNIT_ASSERT(0.0 == defaultConfig.mInputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(0   == defaultConfig.mEfficiencyTable);
+    CPPUNIT_ASSERT(0    == defaultConfig.mInputVoltageSensor);
+    CPPUNIT_ASSERT(0    == defaultConfig.mInputCurrentSensor);
+    CPPUNIT_ASSERT(0    == defaultConfig.mTripPriority);
+    CPPUNIT_ASSERT(0.0F == defaultConfig.mInputUnderVoltageTripLimit);
+    CPPUNIT_ASSERT(0.0F == defaultConfig.mInputOverVoltageTripLimit);
+    CPPUNIT_ASSERT(0    == defaultConfig.mEfficiencyTable);
 
     /// @test    Configuration data copy construction.
     GunnsElectConverterInputConfigData copyConfig(*tConfigData);
     CPPUNIT_ASSERT(&tSensorVin         == copyConfig.mInputVoltageSensor);
     CPPUNIT_ASSERT(&tSensorIin         == copyConfig.mInputCurrentSensor);
     CPPUNIT_ASSERT(tTripPriority       == copyConfig.mTripPriority);
-    CPPUNIT_ASSERT(tInUnderVoltageTrip == copyConfig.mInputUnderVoltageTripLimit);
-    CPPUNIT_ASSERT(tInOverVoltageTrip  == copyConfig.mInputOverVoltageTripLimit);
+    CPPUNIT_ASSERT(tInUnderVoltageTrip == static_cast<double>(copyConfig.mInputUnderVoltageTripLimit));
+    CPPUNIT_ASSERT(tInOverVoltageTrip  == static_cast<double>(copyConfig.mInputOverVoltageTripLimit));
     CPPUNIT_ASSERT(tEfficiencyTable    == copyConfig.mEfficiencyTable);
 
     UT_PASS;
@@ -273,8 +273,8 @@ void UtGunnsElectConverterInput::testNominalInitialization()
     GunnsBasicLink::SolutionResult result;
     CPPUNIT_ASSERT(false == tArticle->mInputUnderVoltageTrip.isTripped());
     CPPUNIT_ASSERT(false == tArticle->mInputOverVoltageTrip.isTripped());
-    CPPUNIT_ASSERT(true  == tArticle->mInputUnderVoltageTrip.checkForTrip(result, tInUnderVoltageTrip - 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true  == tArticle->mInputOverVoltageTrip.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mInputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tInUnderVoltageTrip - 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mInputOverVoltageTrip.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
 
     /// @test    Nominal state data.
     CPPUNIT_ASSERT(false == tArticle->mResetTrips);
@@ -309,9 +309,9 @@ void UtGunnsElectConverterInput::testInitializationErrors()
     UT_RESULT;
 
     /// @test    Exception thrown for under-volt trip limit > over-volt limit.
-    tConfigData->mInputUnderVoltageTripLimit = tInOverVoltageTrip + 0.001;
+    tConfigData->mInputUnderVoltageTripLimit = static_cast<float>(tInOverVoltageTrip + 0.001);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0), TsInitializationException);
-    tConfigData->mInputUnderVoltageTripLimit = tInUnderVoltageTrip;
+    tConfigData->mInputUnderVoltageTripLimit = static_cast<float>(tInUnderVoltageTrip);
 
     /// @test    Exception not thrown for no efficiency table and zero reference power.
     tConfigData->mEfficiencyTable = 0;
@@ -337,7 +337,7 @@ void UtGunnsElectConverterInput::testInitializationErrors()
     tConfigData->mInputOverVoltageTripLimit = 0.0;
     GunnsElectConverterInput article;
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tConfigData, *tInputData, tLinks, tPort0));
-    tConfigData->mInputOverVoltageTripLimit = tInOverVoltageTrip;
+    tConfigData->mInputOverVoltageTripLimit = static_cast<float>(tInOverVoltageTrip);
 
     /// @test    Exception thrown for node list mismatch with output link.
     GunnsBasicNode otherNodes[N_NODES];
@@ -407,8 +407,8 @@ void UtGunnsElectConverterInput::testStep()
 
         /// @test    Reset trips when commanded.
         GunnsBasicLink::SolutionResult result;
-        CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.checkForTrip(result, tInUnderVoltageTrip - 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tInUnderVoltageTrip - 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
         CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.isTripped());
         CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.isTripped());
         tArticle->mResetTrips = true;
@@ -440,8 +440,8 @@ void UtGunnsElectConverterInput::testStep()
         CPPUNIT_ASSERT(false == tArticle->mResetTrips);
 
         /// @test    Trips not reset when not commanded.
-        CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.checkForTrip(result, tInUnderVoltageTrip - 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tInUnderVoltageTrip - 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
         CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip.isTripped());
         CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip.isTripped());
         expectedW = 0.0;
@@ -643,13 +643,13 @@ void UtGunnsElectConverterInput::testComputeInputVoltage()
 
     /// @test    Over-volt tripped.
     GunnsBasicLink::SolutionResult result;
-    CPPUNIT_ASSERT(true  == tArticle->mInputOverVoltageTrip.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mInputOverVoltageTrip.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
     CPPUNIT_ASSERT(true  == tArticle->computeInputVoltage(actualV));
     CPPUNIT_ASSERT(0.0   == actualV);
     tArticle->mInputOverVoltageTrip.resetTrip();
 
     /// @test    Under-volt tripped.
-    CPPUNIT_ASSERT(true  == tArticle->mInputUnderVoltageTrip.checkForTrip(result, tInUnderVoltageTrip - 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mInputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tInUnderVoltageTrip - 0.01), tTripPriority));
     CPPUNIT_ASSERT(true  == tArticle->computeInputVoltage(actualV));
     CPPUNIT_ASSERT(0.0   == actualV);
     tArticle->mInputUnderVoltageTrip.resetTrip();

--- a/aspects/electrical/Converter/test/UtGunnsElectConverterOutput.cpp
+++ b/aspects/electrical/Converter/test/UtGunnsElectConverterOutput.cpp
@@ -101,11 +101,11 @@ void UtGunnsElectConverterOutput::setUp()
                                                                   &tSensorVout,
                                                                   &tSensorIout,
                                                                   tTripPriority,
-                                                                  tOutOverVoltageTrip,
-                                                                  tOutOverCurrentTrip,
+                                                                  static_cast<float>(tOutOverVoltageTrip),
+                                                                  static_cast<float>(tOutOverCurrentTrip),
                                                                   &tInputLink,
                                                                   tEnableLimit,
-                                                                  tOutUnderVoltageTrip);
+                                                                  static_cast<float>(tOutUnderVoltageTrip));
 
     /// - Define the nominal input data.
     tMalfBlockageFlag  = true;
@@ -167,11 +167,11 @@ void UtGunnsElectConverterOutput::testConfig()
     CPPUNIT_ASSERT(&tSensorVout          == tConfigData->mOutputVoltageSensor);
     CPPUNIT_ASSERT(&tSensorIout          == tConfigData->mOutputCurrentSensor);
     CPPUNIT_ASSERT(tTripPriority         == tConfigData->mTripPriority);
-    CPPUNIT_ASSERT(tOutOverVoltageTrip   == tConfigData->mOutputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(tOutOverCurrentTrip   == tConfigData->mOutputOverCurrentTripLimit);
+    CPPUNIT_ASSERT(tOutOverVoltageTrip   == static_cast<double>(tConfigData->mOutputOverVoltageTripLimit));
+    CPPUNIT_ASSERT(tOutOverCurrentTrip   == static_cast<double>(tConfigData->mOutputOverCurrentTripLimit));
     CPPUNIT_ASSERT(&tInputLink           == tConfigData->mInputLink);
     CPPUNIT_ASSERT(true                  == tConfigData->mEnableLimiting);
-    CPPUNIT_ASSERT(tOutUnderVoltageTrip  == tConfigData->mOutputUnderVoltageTripLimit);
+    CPPUNIT_ASSERT(tOutUnderVoltageTrip  == static_cast<double>(tConfigData->mOutputUnderVoltageTripLimit));
     CPPUNIT_ASSERT(4                     == tConfigData->mStateFlipsLimit);
 
     /// @test    Configuration data default construction.
@@ -182,11 +182,11 @@ void UtGunnsElectConverterOutput::testConfig()
     CPPUNIT_ASSERT(0                                  == defaultConfig.mOutputVoltageSensor);
     CPPUNIT_ASSERT(0                                  == defaultConfig.mOutputCurrentSensor);
     CPPUNIT_ASSERT(0                                  == defaultConfig.mTripPriority);
-    CPPUNIT_ASSERT(0.0                                == defaultConfig.mOutputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(0.0                                == defaultConfig.mOutputOverCurrentTripLimit);
+    CPPUNIT_ASSERT(0.0F                               == defaultConfig.mOutputOverVoltageTripLimit);
+    CPPUNIT_ASSERT(0.0F                               == defaultConfig.mOutputOverCurrentTripLimit);
     CPPUNIT_ASSERT(0                                  == defaultConfig.mInputLink);
     CPPUNIT_ASSERT(false                              == defaultConfig.mEnableLimiting);
-    CPPUNIT_ASSERT(0.0                                == defaultConfig.mOutputUnderVoltageTripLimit);
+    CPPUNIT_ASSERT(0.0F                               == defaultConfig.mOutputUnderVoltageTripLimit);
     CPPUNIT_ASSERT(4                                  == defaultConfig.mStateFlipsLimit);
 
     /// @test    Configuration data copy construction.
@@ -197,11 +197,11 @@ void UtGunnsElectConverterOutput::testConfig()
     CPPUNIT_ASSERT(&tSensorVout          == copyConfig.mOutputVoltageSensor);
     CPPUNIT_ASSERT(&tSensorIout          == copyConfig.mOutputCurrentSensor);
     CPPUNIT_ASSERT(tTripPriority         == copyConfig.mTripPriority);
-    CPPUNIT_ASSERT(tOutOverVoltageTrip   == copyConfig.mOutputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(tOutOverCurrentTrip   == copyConfig.mOutputOverCurrentTripLimit);
+    CPPUNIT_ASSERT(tOutOverVoltageTrip   == static_cast<double>(copyConfig.mOutputOverVoltageTripLimit));
+    CPPUNIT_ASSERT(tOutOverCurrentTrip   == static_cast<double>(copyConfig.mOutputOverCurrentTripLimit));
     CPPUNIT_ASSERT(&tInputLink           == copyConfig.mInputLink);
     CPPUNIT_ASSERT(tEnableLimit          == copyConfig.mEnableLimiting);
-    CPPUNIT_ASSERT(tOutUnderVoltageTrip  == copyConfig.mOutputUnderVoltageTripLimit);
+    CPPUNIT_ASSERT(tOutUnderVoltageTrip  == static_cast<double>(copyConfig.mOutputUnderVoltageTripLimit));
     CPPUNIT_ASSERT(4                     == copyConfig.mStateFlipsLimit);
 
     UT_PASS;
@@ -328,9 +328,9 @@ void UtGunnsElectConverterOutput::testNominalInitialization()
     CPPUNIT_ASSERT(false == tArticle->mOutputOverVoltageTrip .isTripped());
     CPPUNIT_ASSERT(false == tArticle->mOutputUnderVoltageTrip.isTripped());
     CPPUNIT_ASSERT(false == tArticle->mOutputOverCurrentTrip .isTripped());
-    CPPUNIT_ASSERT(true  == tArticle->mOutputOverVoltageTrip .checkForTrip(result, tOutOverVoltageTrip  + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true  == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, tOutUnderVoltageTrip - 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true  == tArticle->mOutputOverCurrentTrip .checkForTrip(result, tOutOverCurrentTrip  + 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mOutputOverVoltageTrip .checkForTrip(result, static_cast<float>(tOutOverVoltageTrip  + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tOutUnderVoltageTrip - 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true  == tArticle->mOutputOverCurrentTrip .checkForTrip(result, static_cast<float>(tOutOverCurrentTrip  + 0.01), tTripPriority));
 
     /// @test    Nominal state data.
     CPPUNIT_ASSERT(true  == tArticle->mOutputPowerAvailable);
@@ -464,9 +464,9 @@ void UtGunnsElectConverterOutput::testStep()
 
         /// @test    Reset trips when commanded.
         GunnsBasicLink::SolutionResult result;
-        CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .checkForTrip(result, tOutOverVoltageTrip  + 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, tOutUnderVoltageTrip - 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .checkForTrip(result, tOutOverCurrentTrip  + 0.01, tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .checkForTrip(result, static_cast<float>(tOutOverVoltageTrip  + 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tOutUnderVoltageTrip - 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .checkForTrip(result, static_cast<float>(tOutOverCurrentTrip  + 0.01), tTripPriority));
         CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .isTripped());
         CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.isTripped());
         CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .isTripped());
@@ -482,9 +482,9 @@ void UtGunnsElectConverterOutput::testStep()
         CPPUNIT_ASSERT(false == tArticle->mResetTrips);
 
         /// @test    Trips not reset when not commanded.
-        CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .checkForTrip(result, tOutOverVoltageTrip  + 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, tOutUnderVoltageTrip - 0.01, tTripPriority));
-        CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .checkForTrip(result, tOutOverCurrentTrip  + 0.01, tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .checkForTrip(result, static_cast<float>(tOutOverVoltageTrip  + 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.checkForTrip(result, static_cast<float>(tOutUnderVoltageTrip - 0.01), tTripPriority));
+        CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .checkForTrip(result, static_cast<float>(tOutOverCurrentTrip  + 0.01), tTripPriority));
         CPPUNIT_ASSERT(true == tArticle->mOutputOverVoltageTrip .isTripped());
         CPPUNIT_ASSERT(true == tArticle->mOutputUnderVoltageTrip.isTripped());
         CPPUNIT_ASSERT(true == tArticle->mOutputOverCurrentTrip .isTripped());
@@ -837,12 +837,12 @@ void UtGunnsElectConverterOutput::testAccessors()
     article2.rejectWithLimitState(result, GunnsElectConverterOutput::LIMIT_OC);
     CPPUNIT_ASSERT(1 == article2.mLimitStateFlips);
 
-    CPPUNIT_ASSERT(0.0 == article2.computeVoltageControlSetpoint());
+    CPPUNIT_ASSERT(0.0F == article2.computeVoltageControlSetpoint());
 
     article2.mRegulatorType  = GunnsElectConverterOutput::POWER;
     article2.mLoadResistance = 1.0;
     article2.setSetpoint(1.0);
-    CPPUNIT_ASSERT(1.0 == article2.computeCurrentControlSetpoint());
+    CPPUNIT_ASSERT(1.0F == article2.computeCurrentControlSetpoint());
 
     UT_PASS;
 }
@@ -1054,7 +1054,7 @@ void UtGunnsElectConverterOutput::testConfirmSolutionCurrentSource()
     tArticle->mPotentialVector[0]  = 0.1;
     tArticle->mSourceVoltage       = 0.0;
     tArticle->mLimitStateFlips     = 0;
-    double expectedFlux            = std::max(0.0, tSetpoint - 0.1 * FLT_EPSILON);
+    double expectedFlux            = std::max(0.0, tSetpoint - 0.1 * static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsBasicLink::REJECT              == tArticle->confirmSolutionAcceptable(1, 1));
     CPPUNIT_ASSERT(false                               == tArticle->mOutputUnderVoltageTrip.isTripped());
     CPPUNIT_ASSERT(GunnsElectConverterOutput::LIMIT_UV == tArticle->mLimitState);
@@ -1188,12 +1188,12 @@ void UtGunnsElectConverterOutput::testConfirmSolutionCurrentSource()
 
     /// @test    Rejects due to entering the over-voltage limiting state from over-current limit due
     ///          to excess output voltage.
-    tArticle->mAdmittanceMatrix[0] = FLT_EPSILON;
+    tArticle->mAdmittanceMatrix[0] = static_cast<double>(FLT_EPSILON);
     tArticle->mSourceVector[0]     = tOutOverCurrentTrip;
     tArticle->mPotentialVector[0]  = 200.0;
     tArticle->mLimitStateFlips     = 3;
     tArticle->mInputPowerValid     = true;
-    expectedFlux = tOutOverCurrentTrip - 200.0 * FLT_EPSILON;
+    expectedFlux = tOutOverCurrentTrip - 200.0 * static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT(GunnsBasicLink::REJECT              == tArticle->confirmSolutionAcceptable(1, 1));
     CPPUNIT_ASSERT(GunnsElectConverterOutput::LIMIT_OV == tArticle->mLimitState);
     CPPUNIT_ASSERT(4                                   == tArticle->mLimitStateFlips);
@@ -1207,7 +1207,7 @@ void UtGunnsElectConverterOutput::testConfirmSolutionCurrentSource()
     tArticle->mLimitStateFlips     = 3;
     tArticle->mReverseBiasState    = false;
     tArticle->mInputPowerValid     = true;
-    expectedFlux = tOutOverCurrentTrip - 120.0 * FLT_EPSILON;
+    expectedFlux = tOutOverCurrentTrip - 120.0 * static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT(GunnsBasicLink::REJECT              == tArticle->confirmSolutionAcceptable(1, 1));
     CPPUNIT_ASSERT(GunnsElectConverterOutput::NO_LIMIT == tArticle->mLimitState);
     CPPUNIT_ASSERT(3                                   == tArticle->mLimitStateFlips);

--- a/aspects/electrical/PowerBus/test/UtGunnsElectDistributed2WayBus.cpp
+++ b/aspects/electrical/PowerBus/test/UtGunnsElectDistributed2WayBus.cpp
@@ -90,13 +90,13 @@ void UtGunnsElectDistributed2WayBus::testConstruction()
     CPPUNIT_ASSERT(0                                  == tArticle->mInData.mFrameCount);
     CPPUNIT_ASSERT(0                                  == tArticle->mInData.mFrameLoopback);
     CPPUNIT_ASSERT(false                              == tArticle->mInData.mDemandMode);
-    CPPUNIT_ASSERT(0.0                                == tArticle->mInData.mDemandPower);
-    CPPUNIT_ASSERT(0.0                                == tArticle->mInData.mSupplyVoltage);
+    CPPUNIT_ASSERT(0.0F                               == tArticle->mInData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F                               == tArticle->mInData.mSupplyVoltage);
     CPPUNIT_ASSERT(0                                  == tArticle->mOutData.mFrameCount);
     CPPUNIT_ASSERT(0                                  == tArticle->mOutData.mFrameLoopback);
     CPPUNIT_ASSERT(false                              == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(0.0                                == tArticle->mOutData.mDemandPower);
-    CPPUNIT_ASSERT(0.0                                == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(0.0F                               == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F                               == tArticle->mOutData.mSupplyVoltage);
     CPPUNIT_ASSERT(false                              == tArticle->mIsPairMaster);
     CPPUNIT_ASSERT(GunnsElectDistributed2WayBus::NONE == tArticle->mForcedRole);
     CPPUNIT_ASSERT(0                                  == tArticle->mSupplyDatas.size());
@@ -147,15 +147,15 @@ void UtGunnsElectDistributed2WayBus::testNominalInitialization()
     CPPUNIT_ASSERT(supply3 == tArticle->mSupplyDatas.at(2));
 
     /// @test    Initialize function as primary side.
-    const float voltage = 120.0;
+    const float voltage = 120.0F;
     tArticle->initialize(true, voltage);
 
     CPPUNIT_ASSERT(true    == tArticle->mIsPairMaster);
     CPPUNIT_ASSERT(true    == tArticle->mInData.mDemandMode);
-    CPPUNIT_ASSERT(0.0     == tArticle->mInData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F    == tArticle->mInData.mDemandPower);
     CPPUNIT_ASSERT(voltage == tArticle->mInData.mSupplyVoltage);
     CPPUNIT_ASSERT(false   == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(0.0     == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F    == tArticle->mOutData.mDemandPower);
     CPPUNIT_ASSERT(voltage == tArticle->mOutData.mSupplyVoltage);
 
     /// @test    Initialize function as secondary side.
@@ -164,10 +164,10 @@ void UtGunnsElectDistributed2WayBus::testNominalInitialization()
 
     CPPUNIT_ASSERT(false   == article2.mIsPairMaster);
     CPPUNIT_ASSERT(false   == article2.mInData.mDemandMode);
-    CPPUNIT_ASSERT(0.0     == article2.mInData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F    == article2.mInData.mDemandPower);
     CPPUNIT_ASSERT(voltage == article2.mInData.mSupplyVoltage);
     CPPUNIT_ASSERT(true    == article2.mOutData.mDemandMode);
-    CPPUNIT_ASSERT(0.0     == article2.mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F    == article2.mOutData.mDemandPower);
     CPPUNIT_ASSERT(voltage == article2.mOutData.mSupplyVoltage);
 
     UT_PASS;
@@ -194,7 +194,7 @@ void UtGunnsElectDistributed2WayBus::testUpdateFrameCounts()
     UT_RESULT;
 
     /// - Initialize default constructed test article with nominal initialization data.
-    tArticle->initialize(true, 120.0);
+    tArticle->initialize(true, 120.0F);
 
     /// @test    updateFrameCounts method.
     tArticle->mOutData.mFrameCount   = 43;
@@ -220,7 +220,7 @@ void UtGunnsElectDistributed2WayBus::testUpdate()
     /// - Initialize default constructed test article with nominal initialization data.
     GunnsElectDistributed2WayBusSupplyData* supply1 = tArticle->createSupplyData();
     GunnsElectDistributed2WayBusSupplyData* supply2 = tArticle->createSupplyData();
-    tArticle->initialize(true, 120.0);
+    tArticle->initialize(true, 120.0F);
     tArticle->mOutData.mFrameCount = 43;
 
     GunnsDistributed2WayBusNotification notif;
@@ -231,23 +231,23 @@ void UtGunnsElectDistributed2WayBus::testUpdate()
 
     /// @test    Remain in Supply mode.
     supply1->mAvailable              = true;
-    supply1->mMaximumVoltage         = 120.0;
+    supply1->mMaximumVoltage         = 120.0F;
     supply2->mAvailable              = true;
-    supply2->mMaximumVoltage         = 105.0;
+    supply2->mMaximumVoltage         = 105.0F;
     tArticle->mInData.mDemandMode    = true;
-    tArticle->mInData.mDemandPower   = 100.0;
-    tArticle->mInData.mSupplyVoltage = 110.0;
+    tArticle->mInData.mDemandPower   = 100.0F;
+    tArticle->mInData.mSupplyVoltage = 110.0F;
     tArticle->mInData.mFrameCount    = 44;
     tArticle->mInData.mFrameLoopback = 42;
     tArticle->updateFrameCounts();
-    tArticle->update(119.0, 1.0);
+    tArticle->update(119.0F, 1.0F);
     tArticle->popNotification(notif);
 
-    CPPUNIT_ASSERT(false == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(119.0 == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(0.0   == tArticle->mOutData.mDemandPower);
-    CPPUNIT_ASSERT(NONE  == notif.mLevel);
-    CPPUNIT_ASSERT(""    == notif.mMessage);
+    CPPUNIT_ASSERT(false  == tArticle->mOutData.mDemandMode);
+    CPPUNIT_ASSERT(119.0F == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(0.0F   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(NONE   == notif.mLevel);
+    CPPUNIT_ASSERT(""     == notif.mMessage);
 
     /// @test    Switch to Demand mode.
     supply1->mAvailable              = false;
@@ -257,12 +257,12 @@ void UtGunnsElectDistributed2WayBus::testUpdate()
     tArticle->update(104.0, 1.0);
     tArticle->popNotification(notif);
 
-    CPPUNIT_ASSERT(true  == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(105.0 == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(1.0   == tArticle->mOutData.mDemandPower);
-    CPPUNIT_ASSERT(0     == tArticle->mFramesSinceFlip);
-    CPPUNIT_ASSERT(INFO  == notif.mLevel);
-    CPPUNIT_ASSERT(0     == notif.mMessage.rfind("flipping to Demand role", 0));
+    CPPUNIT_ASSERT(true   == tArticle->mOutData.mDemandMode);
+    CPPUNIT_ASSERT(105.0F == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(1.0F   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0      == tArticle->mFramesSinceFlip);
+    CPPUNIT_ASSERT(INFO   == notif.mLevel);
+    CPPUNIT_ASSERT(0      == notif.mMessage.rfind("flipping to Demand role", 0));
 
     /// @test    Remain in Demand mode, even though our local supply has returned, because not
     ///          enough frames have passed since our flip to Demand.
@@ -270,35 +270,35 @@ void UtGunnsElectDistributed2WayBus::testUpdate()
     tArticle->mInData.mFrameCount    = 46;
     tArticle->mInData.mFrameLoopback = 44;
     tArticle->updateFrameCounts();
-    tArticle->update(119.0, 1.0);
+    tArticle->update(119.0F, 1.0F);
     tArticle->popNotification(notif);
 
     tArticle->mInData.mFrameCount    = 47;
     tArticle->mInData.mFrameLoopback = 45;
     tArticle->updateFrameCounts();
-    tArticle->update(119.0, 1.0);
+    tArticle->update(119.0F, 1.0F);
     tArticle->popNotification(notif);
 
-    CPPUNIT_ASSERT(true  == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(120.0 == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(1.0   == tArticle->mOutData.mDemandPower);
-    CPPUNIT_ASSERT(2     == tArticle->mFramesSinceFlip);
-    CPPUNIT_ASSERT(NONE  == notif.mLevel);
-    CPPUNIT_ASSERT(""    == notif.mMessage);
+    CPPUNIT_ASSERT(true   == tArticle->mOutData.mDemandMode);
+    CPPUNIT_ASSERT(120.0F == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(1.0F   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(2      == tArticle->mFramesSinceFlip);
+    CPPUNIT_ASSERT(NONE   == notif.mLevel);
+    CPPUNIT_ASSERT(""     == notif.mMessage);
 
     /// @test    Switch to Supply mode.
     tArticle->mInData.mFrameCount    = 48;
     tArticle->mInData.mFrameLoopback = 46;
     tArticle->updateFrameCounts();
-    tArticle->update(119.0, 1.0);
+    tArticle->update(119.0F, 1.0F);
     tArticle->popNotification(notif);
 
-    CPPUNIT_ASSERT(false == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(119.0 == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(0.0   == tArticle->mOutData.mDemandPower);
-    CPPUNIT_ASSERT(0     == tArticle->mFramesSinceFlip);
-    CPPUNIT_ASSERT(INFO  == notif.mLevel);
-    CPPUNIT_ASSERT(0     == notif.mMessage.rfind("flipping to Supply role", 0));
+    CPPUNIT_ASSERT(false  == tArticle->mOutData.mDemandMode);
+    CPPUNIT_ASSERT(119.0F == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(0.0F   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0      == tArticle->mFramesSinceFlip);
+    CPPUNIT_ASSERT(INFO   == notif.mLevel);
+    CPPUNIT_ASSERT(0      == notif.mMessage.rfind("flipping to Supply role", 0));
 
     UT_PASS;
 }
@@ -312,7 +312,7 @@ void UtGunnsElectDistributed2WayBus::testUpdateForcedRole()
 
     /// - Initialize default constructed test article with nominal initialization data.
     GunnsElectDistributed2WayBusSupplyData* supply1 = tArticle->createSupplyData();
-    tArticle->initialize(true, 120.0);
+    tArticle->initialize(true, 120.0F);
     tArticle->mOutData.mFrameCount = 43;
 
     GunnsDistributed2WayBusNotification notif;
@@ -323,26 +323,26 @@ void UtGunnsElectDistributed2WayBus::testUpdateForcedRole()
 
     /// @test    Remains in Supply when forced.
     tArticle->mInData.mDemandMode    = true;
-    tArticle->mInData.mDemandPower   = 100.0;
-    tArticle->mInData.mSupplyVoltage = 110.0;
+    tArticle->mInData.mDemandPower   = 100.0F;
+    tArticle->mInData.mSupplyVoltage = 110.0F;
     tArticle->mInData.mFrameCount    = 44;
     tArticle->mInData.mFrameLoopback = 42;
     tArticle->updateFrameCounts();
     tArticle->forceSupplyRole();
-    tArticle->update(2.0, 1.0);
+    tArticle->update(2.0F, 1.0F);
 
     CPPUNIT_ASSERT(false == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(2.0   == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(0.0   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(2.0F  == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(0.0F  == tArticle->mOutData.mDemandPower);
     CPPUNIT_ASSERT(0     == tArticle->mNotifications.size());
 
     /// @test    Force to Demand role.
     tArticle->forceDemandRole();
-    tArticle->update(2.0, 1.0);
+    tArticle->update(2.0F, 1.0F);
 
     CPPUNIT_ASSERT(true  == tArticle->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(0.0   == tArticle->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT(1.0   == tArticle->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F  == tArticle->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(1.0F  == tArticle->mOutData.mDemandPower);
     CPPUNIT_ASSERT(0     == tArticle->mNotifications.size());
 
     UT_PASS;
@@ -367,15 +367,15 @@ void UtGunnsElectDistributed2WayBus::testAccessors()
     CPPUNIT_ASSERT(false == tArticle->isInDemandRole());
 
     /// @test    getRemoteLoad()
-    tArticle->mInData.mDemandPower = 10.0;
+    tArticle->mInData.mDemandPower = 10.0F;
     tArticle->mOutData.mDemandMode = true;
-    CPPUNIT_ASSERT(0.0  == tArticle->getRemoteLoad());
+    CPPUNIT_ASSERT(0.0F  == tArticle->getRemoteLoad());
     tArticle->mOutData.mDemandMode = false;
-    CPPUNIT_ASSERT(10.0 == tArticle->getRemoteLoad());
+    CPPUNIT_ASSERT(10.0F == tArticle->getRemoteLoad());
 
     /// @test    getRemoteSupply()
-    tArticle->mInData.mSupplyVoltage = 100.0;
-    CPPUNIT_ASSERT(100.0 == tArticle->getRemoteSupply());
+    tArticle->mInData.mSupplyVoltage = 100.0F;
+    CPPUNIT_ASSERT(100.0F == tArticle->getRemoteSupply());
 
     UT_PASS_LAST;
 }

--- a/aspects/electrical/PowerBus/test/UtGunnsElectDistributedIf.cpp
+++ b/aspects/electrical/PowerBus/test/UtGunnsElectDistributedIf.cpp
@@ -237,12 +237,12 @@ void UtGunnsElectDistributedIf::testNominalInitialization()
     CPPUNIT_ASSERT(1               == tArticle->mNumSupplies);
     CPPUNIT_ASSERT(1               == tArticle->mSupplies.size());
     CPPUNIT_ASSERT(false           == tArticle->mSupplies.at(0).mSupplyData->mAvailable);
-    CPPUNIT_ASSERT(0.0             == tArticle->mSupplies.at(0).mSupplyData->mMaximumVoltage);
+    CPPUNIT_ASSERT(0.0F            == tArticle->mSupplies.at(0).mSupplyData->mMaximumVoltage);
     CPPUNIT_ASSERT(&tSupply        == tArticle->mSupplies.at(0).mLink);
     CPPUNIT_ASSERT(0.0             == tArticle->mSupplies.at(0).mNetCapDV);
     CPPUNIT_ASSERT(0               == tArticle->mSupplyMonitorIndex);
     CPPUNIT_ASSERT(0               == tArticle->mSupplyMonitor->mSupplyData->mAvailable);
-    CPPUNIT_ASSERT(0.0             == tArticle->mSupplyMonitor->mSupplyData->mMaximumVoltage);
+    CPPUNIT_ASSERT(0.0F            == tArticle->mSupplyMonitor->mSupplyData->mMaximumVoltage);
     CPPUNIT_ASSERT(&tSupply        == tArticle->mSupplyMonitor->mLink);
     CPPUNIT_ASSERT(0.0             == tArticle->mSupplyMonitor->mNetCapDV);
 
@@ -328,10 +328,10 @@ void UtGunnsElectDistributedIf::testStep()
     /// - Drive the inerface's in & out data, in Supply mode.
     tInterface->mOutData.mFrameCount   = 43;
     tInterface->mInData.mDemandMode    = true;
-    tInterface->mInData.mDemandPower   = 100.0;
+    tInterface->mInData.mDemandPower   = 100.0F;
     tInterface->mInData.mFrameCount    = 44;
     tInterface->mInData.mFrameLoopback = 42;
-    tInterface->mInData.mSupplyVoltage = 115.0;
+    tInterface->mInData.mSupplyVoltage = 115.0F;
     tInterface->mFramesSinceFlip       = 99;
 
     /// - Drive the local voltage supply link's output as if it's enabled and controlling.
@@ -351,21 +351,21 @@ void UtGunnsElectDistributedIf::testStep()
     ///          calls minorStep.
     tArticle->mAdmittanceUpdate = true;
     tArticle->step(0.0);
-    CPPUNIT_ASSERT(true  == tInterface->mSupplyDatas.at(0)->mAvailable);
-    CPPUNIT_ASSERT(125.0 == tInterface->mSupplyDatas.at(0)->mMaximumVoltage);
-    CPPUNIT_ASSERT(true  == tArticle->mSupplyMonitor->mSupplyData->mAvailable);
-    CPPUNIT_ASSERT(125.0 == tArticle->mSupplyMonitor->mSupplyData->mMaximumVoltage);
-    CPPUNIT_ASSERT(false == tArticle->mAdmittanceUpdate);
-    CPPUNIT_ASSERT(44    == tInterface->mOutData.mFrameCount);
-    CPPUNIT_ASSERT(false == tInterface->mOutData.mDemandMode);
-    CPPUNIT_ASSERT(115.0 == tVoltageSource->mInputVoltage);
-    CPPUNIT_ASSERT(1.0   == tNodes[0].getNetworkCapacitanceRequest());
-    CPPUNIT_ASSERT(tNodes[0].getPotential() == tInterface->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT(true   == tInterface->mSupplyDatas.at(0)->mAvailable);
+    CPPUNIT_ASSERT(125.0F == tInterface->mSupplyDatas.at(0)->mMaximumVoltage);
+    CPPUNIT_ASSERT(true   == tArticle->mSupplyMonitor->mSupplyData->mAvailable);
+    CPPUNIT_ASSERT(125.0F == tArticle->mSupplyMonitor->mSupplyData->mMaximumVoltage);
+    CPPUNIT_ASSERT(false  == tArticle->mAdmittanceUpdate);
+    CPPUNIT_ASSERT(44     == tInterface->mOutData.mFrameCount);
+    CPPUNIT_ASSERT(false  == tInterface->mOutData.mDemandMode);
+    CPPUNIT_ASSERT(115.0  == tVoltageSource->mInputVoltage);
+    CPPUNIT_ASSERT(1.0    == tNodes[0].getNetworkCapacitanceRequest());
+    CPPUNIT_ASSERT(tNodes[0].getPotential() == static_cast<double>(tInterface->mOutData.mSupplyVoltage));
 
     /// @test    interface update when the voltage source child link has input power not valid.
     tVoltageSource->mInputPowerValid = false;
     tArticle->step(0.0);
-    CPPUNIT_ASSERT(0.0 == tInterface->mOutData.mDemandPower);
+    CPPUNIT_ASSERT(0.0F == tInterface->mOutData.mDemandPower);
 
     UT_PASS;
 }
@@ -417,7 +417,7 @@ void UtGunnsElectDistributedIf::testMinorStep()
     CPPUNIT_ASSERT(true  == tVoltageSource->mEnabled);
     CPPUNIT_ASSERT(false == tPowerLoad->mEnabled);
     CPPUNIT_ASSERT(0.0   == tPowerLoad->mInputPower);
-    CPPUNIT_ASSERT(0.0   == tPowerLoad->getInputUnderVoltageTrip()->getLimit());
+    CPPUNIT_ASSERT(0.0F  == tPowerLoad->getInputUnderVoltageTrip()->getLimit());
 
     /// @test    Minor step in Demand role, with the internal voltage source link failed.
     tArticle->mMalfVoltageSource = true;
@@ -501,10 +501,10 @@ void UtGunnsElectDistributedIf::testComputeFlows()
     tInterface->mOutData.mDemandMode    = false;
     tInterface->mOutData.mFrameCount    = 43;
     tInterface->mInData.mDemandMode     = true;
-    tInterface->mInData.mDemandPower    = 100.0;
+    tInterface->mInData.mDemandPower    = 100.0F;
     tInterface->mInData.mFrameCount     = 44;
     tInterface->mInData.mFrameLoopback  = 42;
-    tInterface->mInData.mSupplyVoltage  = 115.0;
+    tInterface->mInData.mSupplyVoltage  = 115.0F;
     tInterface->mFramesSinceFlip        = 99;
     tNodeNetCapDp[0]                    = 0.0;
     tNodeNetCapDp[1]                    = 1.0;
@@ -515,10 +515,10 @@ void UtGunnsElectDistributedIf::testComputeFlows()
 
     /// @test    computeFlows updates the interface and calls the child links.
     tArticle->computeFlows(0.0);
-    CPPUNIT_ASSERT( 99.0 == tInterface->mOutData.mSupplyVoltage);
-    CPPUNIT_ASSERT( 43   == tInterface->mOutData.mFrameCount);
-    CPPUNIT_ASSERT(-99.0 == tVoltageSource->mPotentialDrop);
-    CPPUNIT_ASSERT( 99.0 == tPowerLoad->mPotentialDrop);
+    CPPUNIT_ASSERT( 99.0F == tInterface->mOutData.mSupplyVoltage);
+    CPPUNIT_ASSERT( 43    == tInterface->mOutData.mFrameCount);
+    CPPUNIT_ASSERT(-99.0  == tVoltageSource->mPotentialDrop);
+    CPPUNIT_ASSERT( 99.0  == tPowerLoad->mPotentialDrop);
 
     UT_PASS_FINAL;
 }

--- a/aspects/electrical/SolarArray/test/UtGunnsElectPvRegConv.cpp
+++ b/aspects/electrical/SolarArray/test/UtGunnsElectPvRegConv.cpp
@@ -300,11 +300,11 @@ void UtGunnsElectPvRegConv::testNominalInitialization()
     /// @test    Trips package.
     GunnsBasicLink::SolutionResult result;
     CPPUNIT_ASSERT(false                    == tArticle->mTrips.isTripped());
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverVoltage.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverCurrent.checkForTrip(result, tInOverCurrentTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverVoltage.checkForTrip(result, tOutOverVoltageTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverCurrent.checkForTrip(result, tOutOverCurrentTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutUnderVoltage.checkForTrip(result, tOutUnderVoltageTrip - 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverVoltage.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverCurrent.checkForTrip(result, static_cast<float>(tInOverCurrentTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverVoltage.checkForTrip(result, static_cast<float>(tOutOverVoltageTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverCurrent.checkForTrip(result, static_cast<float>(tOutOverCurrentTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutUnderVoltage.checkForTrip(result, static_cast<float>(tOutUnderVoltageTrip - 0.01), tTripPriority));
 
     /// @test    Nominal state data.
     CPPUNIT_ASSERT(GunnsElectPvRegConv::OFF == tArticle->mState);
@@ -723,10 +723,10 @@ void UtGunnsElectPvRegConv::testConfirmSolutionAcceptable()
     tArticle->mStateUpmodeLatch = false;
     tArticle->mPotentialVector[0] = 1.0e4;
     CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM  == tArticle->confirmSolutionAcceptable(0, 2));
-    CPPUNIT_ASSERT(0.0 == tArticle->mSensors.mOutVoltage->getSensedOutput());
-    CPPUNIT_ASSERT(0.0 == tArticle->mSensors.mOutCurrent->getSensedOutput());
-    CPPUNIT_ASSERT(0.0 == tArticle->mSensors.mInVoltage->getSensedOutput());
-    CPPUNIT_ASSERT(0.0 == tArticle->mSensors.mInCurrent->getSensedOutput());
+    CPPUNIT_ASSERT(0.0F == tArticle->mSensors.mOutVoltage->getSensedOutput());
+    CPPUNIT_ASSERT(0.0F == tArticle->mSensors.mOutCurrent->getSensedOutput());
+    CPPUNIT_ASSERT(0.0F == tArticle->mSensors.mInVoltage->getSensedOutput());
+    CPPUNIT_ASSERT(0.0F == tArticle->mSensors.mInCurrent->getSensedOutput());
     tArticle->minorStep(0.0, 3);
     tArticle->mStateUpmodeLatch = false;
     tArticle->mPotentialVector[0] = 1.0;
@@ -742,13 +742,13 @@ void UtGunnsElectPvRegConv::testConfirmSolutionAcceptable()
     double actualSensedIin    = tArticle->mSensors.mInCurrent->getSensedOutput();
     double actualSensedVout   = tArticle->mSensors.mOutVoltage->getSensedOutput();
     double actualSensedIout   = tArticle->mSensors.mOutCurrent->getSensedOutput();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVin,  actualSensedVin,  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIin,  actualSensedIin,  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, FLT_EPSILON * expectedSensedVout);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIout, actualSensedIout, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVin,  actualSensedVin,  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIin,  actualSensedIin,  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, static_cast<double>(FLT_EPSILON) * expectedSensedVout);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIout, actualSensedIout, static_cast<double>(FLT_EPSILON));
 
     /// @test    Trips occur on prioritized converged minor step.
-    CPPUNIT_ASSERT(tOutOverCurrentTrip < tArticle->mSensors.mOutCurrent->getSensedOutput());
+    CPPUNIT_ASSERT(tOutOverCurrentTrip < static_cast<double>(tArticle->mSensors.mOutCurrent->getSensedOutput()));
     CPPUNIT_ASSERT(false == tArticle->mTrips.isTripped());
     CPPUNIT_ASSERT(GunnsBasicLink::REJECT     == tArticle->confirmSolutionAcceptable(2, 4));
     CPPUNIT_ASSERT(GunnsElectPvRegConv::OFF   == tArticle->mState);
@@ -780,7 +780,7 @@ void UtGunnsElectPvRegConv::testConfirmSolutionAcceptable()
     tArray->mSections[2].setSourceExposedFraction(1.0);
     tArray->step(0.0);
 
-    tArticle->mTrips.mOutOverCurrent.initialize(0.1, tTripPriority, false);
+    tArticle->mTrips.mOutOverCurrent.initialize(0.1F, tTripPriority, false);
     tArticle->mState = GunnsElectPvRegConv::REG;
     double outputVolts = expectedVreg - 1.0e-8;
     tArticle->mPotentialVector[0] = outputVolts;

--- a/aspects/electrical/SolarArray/test/UtGunnsElectPvRegShunt.cpp
+++ b/aspects/electrical/SolarArray/test/UtGunnsElectPvRegShunt.cpp
@@ -322,11 +322,11 @@ void UtGunnsElectPvRegShunt::testNominalInitialization()
     /// @test    Trips package.
     GunnsBasicLink::SolutionResult result;
     CPPUNIT_ASSERT(false                     == tArticle->mTrips.isTripped());
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverVoltage.checkForTrip(result, tInOverVoltageTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverCurrent.checkForTrip(result, tInOverCurrentTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverVoltage.checkForTrip(result, tOutOverVoltageTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverCurrent.checkForTrip(result, tOutOverCurrentTrip + 0.01, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutUnderVoltage.checkForTrip(result, tOutUnderVoltageTrip - 0.01, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverVoltage.checkForTrip(result, static_cast<float>(tInOverVoltageTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mInOverCurrent.checkForTrip(result, static_cast<float>(tInOverCurrentTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverVoltage.checkForTrip(result, static_cast<float>(tOutOverVoltageTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutOverCurrent.checkForTrip(result, static_cast<float>(tOutOverCurrentTrip + 0.01), tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mTrips.mOutUnderVoltage.checkForTrip(result, static_cast<float>(tOutUnderVoltageTrip - 0.01), tTripPriority));
 
     /// @test    Nominal state data.
     CPPUNIT_ASSERT(GunnsElectPvRegShunt::OFF == tArticle->mState);
@@ -768,7 +768,7 @@ void UtGunnsElectPvRegShunt::testConfirmSolutionAcceptable()
     tArray->mSections[0].mStrings[0].loadAtConductance(tShuntConductance);
     const double shuntedStringP = tArray->mSections[0].mStrings[0].getTerminal().mPower;
 
-    const int numLoadedStrings   = ceil(powerDemand / loadedStringP);
+    const int numLoadedStrings   = static_cast<int>(std::ceil(powerDemand / loadedStringP));
     const int numShuntedStrings  = tArrayConfig->mNumStrings - numLoadedStrings;
     const int firstLoadedSection = tArrayConfig->mNumSections - 1;
     const int firstLoadedString  = tArrayConfig->mNumStrings / tArrayConfig->mNumSections - 1;
@@ -781,10 +781,10 @@ void UtGunnsElectPvRegShunt::testConfirmSolutionAcceptable()
 
     CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM   == tArticle->confirmSolutionAcceptable(1, 2));
     CPPUNIT_ASSERT(GunnsElectPvRegShunt::REG == tArticle->mState);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPin,   tArticle->mInputPower,       FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedGin,   tArticle->mInputConductance, FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPsh,   tArticle->mShuntPower,       FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux,  tArticle->mFlux,             FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPin,   tArticle->mInputPower,       static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedGin,   tArticle->mInputConductance, static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPsh,   tArticle->mShuntPower,       static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux,  tArticle->mFlux,             static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(false == tArray->mCommonStringsOutput);
     CPPUNIT_ASSERT(true  == tArray->mSections[0].mStrings[0].isShunted());
     CPPUNIT_ASSERT(false == tArray->mSections[firstLoadedSection].mStrings[firstLoadedString].isShunted());
@@ -798,10 +798,10 @@ void UtGunnsElectPvRegShunt::testConfirmSolutionAcceptable()
     double actualSensedIin    = tArticle->mSensors.mInCurrent->getSensedOutput();
     double actualSensedVout   = tArticle->mSensors.mOutVoltage->getSensedOutput();
     double actualSensedIout   = tArticle->mSensors.mOutCurrent->getSensedOutput();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVin,  actualSensedVin,  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIin,  actualSensedIin,  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, FLT_EPSILON * expectedSensedVout);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIout, actualSensedIout, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVin,  actualSensedVin,  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIin,  actualSensedIin,  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, static_cast<double>(FLT_EPSILON) * expectedSensedVout);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedIout, actualSensedIout, static_cast<double>(FLT_EPSILON));
 
     /// @test    Transition from REG -> OFF due to insufficient array power, only after solution is
     ///          converged, and all strings are shunted.  This tests the scenario where
@@ -898,7 +898,7 @@ void UtGunnsElectPvRegShunt::testConfirmSolutionAcceptable()
     CPPUNIT_ASSERT(GunnsElectPvRegShunt::OFF == tArticle->mState);
     expectedSensedVout = outputVolts;
     actualSensedVout   = tArticle->mSensors.mOutVoltage->getSensedOutput();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, FLT_EPSILON * expectedSensedVout);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, actualSensedVout, static_cast<double>(FLT_EPSILON) * expectedSensedVout);
 
     UT_PASS;
 }

--- a/aspects/electrical/SolarArray/test/UtGunnsElectPvSection.cpp
+++ b/aspects/electrical/SolarArray/test/UtGunnsElectPvSection.cpp
@@ -137,8 +137,8 @@ void UtGunnsElectPvSection::testConfig()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tRefSourceFluxMagnitude,     tConfigData->mRefSourceFluxMagnitude,                 0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBlockingDiodeVoltageDrop,   tConfigData->mStringConfig.mBlockingDiodeVoltageDrop, 0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBypassDiodeVoltageDrop,     tConfigData->mStringConfig.mBypassDiodeVoltageDrop,   0.0);
-    CPPUNIT_ASSERT(tBypassDiodeInterval == tConfigData->mStringConfig.mBypassDiodeInterval);
-    CPPUNIT_ASSERT(tNumCells            == tConfigData->mStringConfig.mNumCells);
+    CPPUNIT_ASSERT(tBypassDiodeInterval == static_cast<int>(tConfigData->mStringConfig.mBypassDiodeInterval));
+    CPPUNIT_ASSERT(tNumCells            == static_cast<int>(tConfigData->mStringConfig.mNumCells));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tCellSurfaceArea,             tConfigData->mStringConfig.mCellConfig.mSurfaceArea,             0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tCellEfficiency,              tConfigData->mStringConfig.mCellConfig.mEfficiency,              0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tCellSeriesResistance,        tConfigData->mStringConfig.mCellConfig.mSeriesResistance,        0.0);

--- a/aspects/electrical/SolarArray/test/UtGunnsElectPvString.cpp
+++ b/aspects/electrical/SolarArray/test/UtGunnsElectPvString.cpp
@@ -246,8 +246,8 @@ void UtGunnsElectPvString::testConfig()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBlockingDiodeVoltageDrop, tConfigData->mBlockingDiodeVoltageDrop, 0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBypassDiodeVoltageDrop,   tConfigData->mBypassDiodeVoltageDrop,   0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tCellSurfaceArea,          tConfigData->mCellConfig.mSurfaceArea,  0.0);
-    CPPUNIT_ASSERT(tBypassDiodeInterval == tConfigData->mBypassDiodeInterval);
-    CPPUNIT_ASSERT(tNumCells            == tConfigData->mNumCells);
+    CPPUNIT_ASSERT(tBypassDiodeInterval == static_cast<int>(tConfigData->mBypassDiodeInterval));
+    CPPUNIT_ASSERT(tNumCells            == static_cast<int>(tConfigData->mNumCells));
 
     /// @test    Configuration data default construction.
     GunnsElectPvStringConfigData defaultConfig;
@@ -263,8 +263,8 @@ void UtGunnsElectPvString::testConfig()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBlockingDiodeVoltageDrop, assignConfig.mBlockingDiodeVoltageDrop, 0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tBypassDiodeVoltageDrop,   assignConfig.mBypassDiodeVoltageDrop,   0.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tCellSurfaceArea,          assignConfig.mCellConfig.mSurfaceArea,  0.0);
-    CPPUNIT_ASSERT(tBypassDiodeInterval == assignConfig.mBypassDiodeInterval);
-    CPPUNIT_ASSERT(tNumCells            == assignConfig.mNumCells);
+    CPPUNIT_ASSERT(tBypassDiodeInterval == static_cast<int>(assignConfig.mBypassDiodeInterval));
+    CPPUNIT_ASSERT(tNumCells            == static_cast<int>(assignConfig.mNumCells));
 
     /// @test    Configuration data self assign.
     GunnsElectPvStringConfigData* assignConfig2 = &assignConfig;

--- a/aspects/electrical/Switch/test/UtGunnsElectSwitchUtil2.cpp
+++ b/aspects/electrical/Switch/test/UtGunnsElectSwitchUtil2.cpp
@@ -51,7 +51,7 @@ void UtGunnsElectSwitchUtil2::setUp()
     tName = "tArticle";
 
     /// - Create nominal config data.
-    tResistance   = 0.0668;
+    tResistance   = 0.0668F;
     tTripPriority = 3;
 
     tConfigData = new GunnsElectSwitchUtil2ConfigData(tResistance, tTripPriority);
@@ -112,8 +112,8 @@ void UtGunnsElectSwitchUtil2::testConfigData()
 
     /// @test    Default construction.
     GunnsElectSwitchUtil2ConfigData defaultConfig;
-    CPPUNIT_ASSERT(0.0 == defaultConfig.mResistance);
-    CPPUNIT_ASSERT(0   == defaultConfig.mTripPriority);
+    CPPUNIT_ASSERT(0.0F == defaultConfig.mResistance);
+    CPPUNIT_ASSERT(0    == defaultConfig.mTripPriority);
 
     /// @test    Assignment operator.
     GunnsElectSwitchUtil2ConfigData assignConfig;
@@ -159,12 +159,12 @@ void UtGunnsElectSwitchUtil2::testInputData()
     CPPUNIT_ASSERT(false == defaultInput.mPosition);
     CPPUNIT_ASSERT(false == defaultInput.mPositionCommand);
     CPPUNIT_ASSERT(false == defaultInput.mResetTripsCommand);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mInputUnderVoltageTripLimit);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mInputUnderVoltageTripReset);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mInputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mInputOverVoltageTripReset);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mPosOverCurrentTripLimit);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mNegOverCurrentTripLimit);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mInputUnderVoltageTripLimit);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mInputUnderVoltageTripReset);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mInputOverVoltageTripLimit);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mInputOverVoltageTripReset);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mPosOverCurrentTripLimit);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mNegOverCurrentTripLimit);
 
     /// @test    Assignment operator.
     GunnsElectSwitchUtil2InputData assignInput;
@@ -196,12 +196,12 @@ void UtGunnsElectSwitchUtil2::testDefaultConstruction()
     CPPUNIT_ASSERT(false == article.mPosition);
     CPPUNIT_ASSERT(false == article.mPositionCommand);
     CPPUNIT_ASSERT(false == article.mResetTripsCommand);
-    CPPUNIT_ASSERT(0.0   == article.mInputUnderVoltageTrip.getLimit());
-    CPPUNIT_ASSERT(0.0   == article.mInputUnderVoltageReset.getLimit());
-    CPPUNIT_ASSERT(0.0   == article.mInputOverVoltageTrip.getLimit());
-    CPPUNIT_ASSERT(0.0   == article.mInputOverVoltageReset.getLimit());
-    CPPUNIT_ASSERT(0.0   == article.mPosOverCurrentTrip.getLimit());
-    CPPUNIT_ASSERT(0.0   == article.mNegOverCurrentTrip.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mInputUnderVoltageTrip.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mInputUnderVoltageReset.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mInputOverVoltageTrip.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mInputOverVoltageReset.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mPosOverCurrentTrip.getLimit());
+    CPPUNIT_ASSERT(0.0F  == article.mNegOverCurrentTrip.getLimit());
     CPPUNIT_ASSERT(false == article.mWaitingToTrip);
     CPPUNIT_ASSERT(false == article.mJustTripped);
     CPPUNIT_ASSERT(""    == article.mName);
@@ -265,12 +265,12 @@ void UtGunnsElectSwitchUtil2::testInitializationErrors()
     tConfigData->mResistance = tResistance;
 
     /// @test    Error thrown for IUV trip reset less than trip value.
-    tInputData->mInputUnderVoltageTripReset = tInputUnderVoltageTripLimit - 0.001;
+    tInputData->mInputUnderVoltageTripReset = tInputUnderVoltageTripLimit - 0.001F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tName), TsInitializationException);
     tInputData->mInputUnderVoltageTripReset = tInputUnderVoltageTripReset;
 
     /// @test    Error thrown for IOV trip reset greater than trip value.
-    tInputData->mInputOverVoltageTripReset = tInputOverVoltageTripLimit + 0.001;
+    tInputData->mInputOverVoltageTripReset = tInputOverVoltageTripLimit + 0.001F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tName), TsInitializationException);
     tInputData->mInputOverVoltageTripReset = tInputOverVoltageTripReset;
 
@@ -298,7 +298,7 @@ void UtGunnsElectSwitchUtil2::testInputConstraints()
     /// @test    constraint on input under-volt trip reset value is applied.
     {
         const float expectedLimit = tArticle->mInputUnderVoltageTrip.getLimit();
-        tArticle->mInputUnderVoltageReset.setLimit(expectedLimit - 0.001);
+        tArticle->mInputUnderVoltageReset.setLimit(expectedLimit - 0.001F);
         tArticle->updateState();
         CPPUNIT_ASSERT(expectedLimit == tArticle->mInputUnderVoltageReset.getLimit());
     }
@@ -306,7 +306,7 @@ void UtGunnsElectSwitchUtil2::testInputConstraints()
     /// @test    constraint on input over-volt trip reset value is applied.
     {
         const float expectedLimit = tArticle->mInputOverVoltageTrip.getLimit();
-        tArticle->mInputOverVoltageReset.setLimit(expectedLimit + 0.001);
+        tArticle->mInputOverVoltageReset.setLimit(expectedLimit + 0.001F);
         tArticle->updateState();
         CPPUNIT_ASSERT(expectedLimit == tArticle->mInputOverVoltageReset.getLimit());
     }
@@ -329,12 +329,12 @@ void UtGunnsElectSwitchUtil2::testUpdateState()
 
     /// - Set the trips.
     GunnsBasicLink::SolutionResult result = GunnsBasicLink::CONFIRM;
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001F, tTripPriority));
 
     /// @test    Tripped switch remains tripped if commanded closed, and stays open when tripped
     ///          and commanded closed.
@@ -362,12 +362,12 @@ void UtGunnsElectSwitchUtil2::testUpdateState()
     CPPUNIT_ASSERT(false == tArticle->mWaitingToTrip);
 
     /// - Set the trips.
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001F, tTripPriority));
 
     /// @test    Trips are reset if commanded to reset.
     tArticle->mJustTripped       = true;
@@ -404,12 +404,12 @@ void UtGunnsElectSwitchUtil2::testUpdateState()
     CPPUNIT_ASSERT(true == tArticle->mPosition);
 
     /// - Set the trips.
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001, tTripPriority));
-    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageTrip .checkForTrip(result, tInputUnderVoltageTripLimit - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputUnderVoltageReset.checkForTrip(result, tInputUnderVoltageTripReset + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageTrip  .checkForTrip(result, tInputOverVoltageTripLimit  + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mInputOverVoltageReset .checkForTrip(result, tInputOverVoltageTripReset  - 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mPosOverCurrentTrip    .checkForTrip(result, tPosOverCurrentTripLimit    + 0.001F, tTripPriority));
+    CPPUNIT_ASSERT(true == tArticle->mNegOverCurrentTrip    .checkForTrip(result, tNegOverCurrentTripLimit    - 0.001F, tTripPriority));
 
     /// @test    Fail closed malf overrides trips.
     tArticle->updateState();
@@ -433,7 +433,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
     tArticle->initialize(*tConfigData, *tInputData, tName);
 
     /// @test    no trips for any trip condition if not converged.
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripLimit + 1.0, 0);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripLimit + 1.0F, 0);
 
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
@@ -447,7 +447,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    no trips if failed closed.
     tArticle->setMalfFailClosed(true);
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripLimit + 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripLimit + 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -460,7 +460,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    waiting to trip for any trip condition if not on trip priority step.
     tArticle->setMalfFailClosed();
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripLimit + 1.0, 2);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripLimit + 1.0F, 2);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -472,7 +472,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
     CPPUNIT_ASSERT(true  == tArticle->mPosition);
 
     /// @test    +OC trip.
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripReset - 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripReset - 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -485,7 +485,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    -OC trip.
     tArticle->resetTrips();
-    tArticle->updateTrips(tNegOverCurrentTripLimit - 1.0, tInputOverVoltageTripReset - 1.0, 3);
+    tArticle->updateTrips(tNegOverCurrentTripLimit - 1.0F, tInputOverVoltageTripReset - 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -498,7 +498,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    IUV trip.
     tArticle->resetTrips();
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputUnderVoltageTripLimit - 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputUnderVoltageTripLimit - 1.0F, 3);
     CPPUNIT_ASSERT(true == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -511,7 +511,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    No trip resets if failed open.
     tArticle->setMalfFailOpen(true);
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputUnderVoltageTripReset + 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputUnderVoltageTripReset + 1.0F, 3);
     CPPUNIT_ASSERT(true  == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -524,7 +524,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    IUV trip reset.
     tArticle->setMalfFailOpen();
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputUnderVoltageTripReset + 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputUnderVoltageTripReset + 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -537,7 +537,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    IOV trip simo with +OC trip.
     tArticle->resetTrips();
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripLimit + 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripLimit + 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(true  == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -549,7 +549,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
     CPPUNIT_ASSERT(false == tArticle->mPosition);
 
     /// @test    IOV trip reset prevented by present +OC trip.
-    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0, tInputOverVoltageTripReset - 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit + 1.0F, tInputOverVoltageTripReset - 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(true  == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -562,7 +562,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
 
     /// @test    IOV trip.
     tArticle->resetTrips();
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputOverVoltageTripLimit + 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputOverVoltageTripLimit + 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(true  == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -574,7 +574,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
     CPPUNIT_ASSERT(false == tArticle->mPosition);
 
     /// @test     waiting to IOV trip reset.
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputOverVoltageTripReset - 1.0, 2);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputOverVoltageTripReset - 1.0F, 2);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(true  == tArticle->getInputOverVoltageTrip()->isTripped());
@@ -586,7 +586,7 @@ void UtGunnsElectSwitchUtil2::testUpdateTrips()
     CPPUNIT_ASSERT(false == tArticle->getPosition());
 
     /// @test     IOV trip reset.
-    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0, tInputOverVoltageTripReset - 1.0, 3);
+    tArticle->updateTrips(tPosOverCurrentTripLimit - 1.0F, tInputOverVoltageTripReset - 1.0F, 3);
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageTrip()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputUnderVoltageReset()->isTripped());
     CPPUNIT_ASSERT(false == tArticle->getInputOverVoltageTrip()->isTripped());

--- a/aspects/electrical/Switch/test/UtGunnsElectUserLoadSwitch.cpp
+++ b/aspects/electrical/Switch/test/UtGunnsElectUserLoadSwitch.cpp
@@ -683,10 +683,10 @@ void UtGunnsElectUserLoadSwitch::testComputeFlowsOverrideNonGround()
 
         CPPUNIT_ASSERT_NO_THROW(tArticle->computeFlows(0.0));
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDp,   tArticle->mPotentialDrop,                DBL_EPSILON);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, tArticle->mFlux,                         FLT_EPSILON * expectedFlux);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mPower,                        FLT_EPSILON * expectedPwr);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, tArticle->mFlux,                         static_cast<double>(FLT_EPSILON) * expectedFlux);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mPower,                        static_cast<double>(FLT_EPSILON) * expectedPwr);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,          tArticle->mSwitch.getPowerDissipation(), DBL_EPSILON);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mLoadsPower,                   FLT_EPSILON * expectedPwr);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mLoadsPower,                   static_cast<double>(FLT_EPSILON) * expectedPwr);
     }
 
     UT_PASS;

--- a/aspects/electrical/Switch/test/UtGunnsElectUserLoadSwitch2.cpp
+++ b/aspects/electrical/Switch/test/UtGunnsElectUserLoadSwitch2.cpp
@@ -22,14 +22,14 @@ UtGunnsElectUserLoadSwitch2::UtGunnsElectUserLoadSwitch2()
     tNodes(),
     tNodeList(),
     tPorts(),
-    tSwitchResistance(0.0),
+    tSwitchResistance(0.0F),
     tSwitchTripPriority(0),
-    tCurrentSensorMinRange(0.0),
-    tCurrentSensorMaxRange(0.0),
-    tInputVoltageSensorMinRange(0.0),
-    tInputVoltageSensorMaxRange(0.0),
-    tOutputVoltageSensorMinRange(0.0),
-    tOutputVoltageSensorMaxRange(0.0),
+    tCurrentSensorMinRange(0.0F),
+    tCurrentSensorMaxRange(0.0F),
+    tInputVoltageSensorMinRange(0.0F),
+    tInputVoltageSensorMaxRange(0.0F),
+    tOutputVoltageSensorMinRange(0.0F),
+    tOutputVoltageSensorMaxRange(0.0F),
     tConfigData(0),
     tMalfBlockageFlag(false),
     tMalfBlockageValue(0.0),
@@ -82,14 +82,14 @@ void UtGunnsElectUserLoadSwitch2::setUp()
 
     /// - Define the nominal configuration data.
     tName                        = "nominal";
-    tSwitchResistance            =   0.1;
+    tSwitchResistance            =   0.1F;
     tSwitchTripPriority          =   2;
-    tCurrentSensorMinRange       = -10.0;
-    tCurrentSensorMaxRange       =  10.0;
-    tInputVoltageSensorMinRange  =   0.0;
-    tInputVoltageSensorMaxRange  = 200.0;
-    tOutputVoltageSensorMinRange =  -1.0;
-    tOutputVoltageSensorMaxRange = 180.0;
+    tCurrentSensorMinRange       = -10.0F;
+    tCurrentSensorMaxRange       =  10.0F;
+    tInputVoltageSensorMinRange  =   0.0F;
+    tInputVoltageSensorMaxRange  = 200.0F;
+    tOutputVoltageSensorMinRange =  -1.0F;
+    tOutputVoltageSensorMaxRange = 180.0F;
     tConfigData                  = new GunnsElectUserLoadSwitch2ConfigData(tName,
                                                                           &tNodeList,
                                                                            tSwitchResistance,
@@ -182,7 +182,7 @@ void UtGunnsElectUserLoadSwitch2::testConfig()
     CPPUNIT_ASSERT(tNodes                       == tConfigData->mNodeList->mNodes);
     CPPUNIT_ASSERT(0.0                          == tConfigData->mDefaultConductivity);
     CPPUNIT_ASSERT(tSwitchResistance            == tConfigData->mSwitch.mResistance);
-    CPPUNIT_ASSERT(tSwitchTripPriority          == tConfigData->mSwitch.mTripPriority);
+    CPPUNIT_ASSERT(tSwitchTripPriority          == static_cast<int>(tConfigData->mSwitch.mTripPriority));
     CPPUNIT_ASSERT(tCurrentSensorMinRange       == tConfigData->mCurrentSensor.mMinRange);
     CPPUNIT_ASSERT(tCurrentSensorMaxRange       == tConfigData->mCurrentSensor.mMaxRange);
     CPPUNIT_ASSERT(TsNoise::getNoiseFunction()  == tConfigData->mCurrentSensor.mNoiseFunction);
@@ -209,12 +209,12 @@ void UtGunnsElectUserLoadSwitch2::testInput()
     CPPUNIT_ASSERT(tSwitchIsClosed             == tInputData->mSwitch.mPosition);
     CPPUNIT_ASSERT(tSwitchIsClosed             == tInputData->mSwitch.mPositionCommand);
     CPPUNIT_ASSERT(false                       == tInputData->mSwitch.mResetTripsCommand);
-    CPPUNIT_ASSERT(tInputUnderVoltageTripLimit == tInputData->mSwitch.mInputUnderVoltageTripLimit);
-    CPPUNIT_ASSERT(tInputUnderVoltageTripReset == tInputData->mSwitch.mInputUnderVoltageTripReset);
-    CPPUNIT_ASSERT(tInputOverVoltageTripLimit  == tInputData->mSwitch.mInputOverVoltageTripLimit);
-    CPPUNIT_ASSERT(tInputOverVoltageTripReset  == tInputData->mSwitch.mInputOverVoltageTripReset);
-    CPPUNIT_ASSERT(tSwitchPosTripLimit         == tInputData->mSwitch.mPosOverCurrentTripLimit);
-    CPPUNIT_ASSERT(tSwitchNegTripLimit         == tInputData->mSwitch.mNegOverCurrentTripLimit);
+    CPPUNIT_ASSERT(tInputUnderVoltageTripLimit == static_cast<double>(tInputData->mSwitch.mInputUnderVoltageTripLimit));
+    CPPUNIT_ASSERT(tInputUnderVoltageTripReset == static_cast<double>(tInputData->mSwitch.mInputUnderVoltageTripReset));
+    CPPUNIT_ASSERT(tInputOverVoltageTripLimit  == static_cast<double>(tInputData->mSwitch.mInputOverVoltageTripLimit));
+    CPPUNIT_ASSERT(tInputOverVoltageTripReset  == static_cast<double>(tInputData->mSwitch.mInputOverVoltageTripReset));
+    CPPUNIT_ASSERT(tSwitchPosTripLimit         == static_cast<double>(tInputData->mSwitch.mPosOverCurrentTripLimit));
+    CPPUNIT_ASSERT(tSwitchNegTripLimit         == static_cast<double>(tInputData->mSwitch.mNegOverCurrentTripLimit));
     CPPUNIT_ASSERT(tLoadsOverrideActive        == tInputData->mLoadsOverrideActive);
     CPPUNIT_ASSERT(tLoadsOverrideVoltage       == tInputData->mLoadsOverrideVoltage);
 
@@ -415,9 +415,9 @@ void UtGunnsElectUserLoadSwitch2::testStep()
         CPPUNIT_ASSERT(true == tLoadCp.getLoad()->getPowerValid());
         CPPUNIT_ASSERT(true == tArticle->needAdmittanceUpdate());
 
-        double expectedSensedI    = flux                          + tArticle->mCurrentSensor.mMalfDriftRate       * timestep;
-        double expectedSensedVin  = tArticle->mPotentialVector[0] + tArticle->mInputVoltageSensor.mMalfDriftRate  * timestep;
-        double expectedSensedVout = expectedLoadsV                + tArticle->mOutputVoltageSensor.mMalfDriftRate * timestep;
+        double expectedSensedI    = flux                          + static_cast<double>(tArticle->mCurrentSensor.mMalfDriftRate)       * timestep;
+        double expectedSensedVin  = tArticle->mPotentialVector[0] + static_cast<double>(tArticle->mInputVoltageSensor.mMalfDriftRate)  * timestep;
+        double expectedSensedVout = expectedLoadsV                + static_cast<double>(tArticle->mOutputVoltageSensor.mMalfDriftRate) * timestep;
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedI,    static_cast<double>(tArticle->mCurrentSensor.getSensedOutput()),       1.0e-3);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVin,  static_cast<double>(tArticle->mInputVoltageSensor.getSensedOutput()),  1.0e-3);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSensedVout, static_cast<double>(tArticle->mOutputVoltageSensor.getSensedOutput()), 1.0e-3);
@@ -647,7 +647,7 @@ void UtGunnsElectUserLoadSwitch2::testComputeFlows()
         double expectedA       = expectedG * (1.0 - tInputData->mMalfBlockageValue);
         double expectedFlux    = expectedA * (tNodes[tPorts[0]].getPotential() - tNodes[tPorts[1]].getPotential());
         double expectedPower   = -expectedFlux * tNodes[tPorts[0]].getPotential();
-        double expectedLoadPwr = -expectedPower - expectedFlux * expectedFlux * tSwitchResistance;
+        double expectedLoadPwr = -expectedPower - expectedFlux * expectedFlux * static_cast<double>(tSwitchResistance);
 
         CPPUNIT_ASSERT_NO_THROW(tArticle->computeFlows(0.0));
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux,      tArticle->mFlux,                         DBL_EPSILON);
@@ -737,9 +737,9 @@ void UtGunnsElectUserLoadSwitch2::testComputeFlowsOverrideNonGround()
 
         CPPUNIT_ASSERT_NO_THROW(tArticle->computeFlows(0.0));
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDp,   tArticle->mPotentialDrop,                DBL_EPSILON);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, tArticle->mFlux,                         FLT_EPSILON * expectedFlux);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mPower,                        FLT_EPSILON * expectedPwr);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mLoadsPower,                   FLT_EPSILON * expectedPwr);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, tArticle->mFlux,                         static_cast<double>(FLT_EPSILON) * expectedFlux);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mPower,                        static_cast<double>(FLT_EPSILON) * expectedPwr);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPwr,  tArticle->mLoadsPower,                   static_cast<double>(FLT_EPSILON) * expectedPwr);
     }
 
     UT_PASS;
@@ -932,14 +932,14 @@ void UtGunnsElectUserLoadSwitch2::testInitializationExceptions()
     tConfigData->mName = tName;
 
     /// @test    Initialization exception from the switch.
-    tConfigData->mSwitch.mResistance = 0.0;
+    tConfigData->mSwitch.mResistance = 0.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPorts[0], tPorts[1]),
                          TsInitializationException);
     CPPUNIT_ASSERT(!tArticle->isInitialized());
     tConfigData->mSwitch.mResistance = tSwitchResistance;
 
     /// @test    Initialization exception from a sensor.
-    tConfigData->mInputVoltageSensor.mMaxRange = -99.9;
+    tConfigData->mInputVoltageSensor.mMaxRange = -99.9F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPorts[0], tPorts[1]),
                          TsInitializationException);
     CPPUNIT_ASSERT(!tArticle->isInitialized());

--- a/aspects/electrical/SwitchCard/test/UtSwitchCard.cpp
+++ b/aspects/electrical/SwitchCard/test/UtSwitchCard.cpp
@@ -111,10 +111,10 @@ void UtSwitchCard::setUp() {
     tMinInputVoltage = 70.0;
     tMaxConductance = 1.3E5;
 
-    tInputVoltSensorConfigData = SensorAnalogConfigData(0.0, 140.0, 0.0, 0.0, 1.0, 0.0, 0.001, 0, UnitConversion::NO_CONVERSION);
-    tInputCurrentSensorConfigData = SensorAnalogConfigData(-125.0, 125.0, 0.0, 0.0, 1.0, 0.0, 0.001, 0, UnitConversion::NO_CONVERSION);
-    tSwitchVoltSensorConfigData = SensorAnalogConfigData(0.0, 250.0, 0.0, 0.0, 1.0, 0.0, 0.001, 0, UnitConversion::NO_CONVERSION);
-    tSwitchCurrentSensorConfigData = SensorAnalogConfigData(-250.0, 250.0, 0.0, 0.0, 1.0, 0.0, 0.001, 0, UnitConversion::NO_CONVERSION);
+    tInputVoltSensorConfigData = SensorAnalogConfigData(0.0F, 140.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.001F, 0, UnitConversion::NO_CONVERSION);
+    tInputCurrentSensorConfigData = SensorAnalogConfigData(-125.0F, 125.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.001F, 0, UnitConversion::NO_CONVERSION);
+    tSwitchVoltSensorConfigData = SensorAnalogConfigData(0.0F, 250.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.001F, 0, UnitConversion::NO_CONVERSION);
+    tSwitchCurrentSensorConfigData = SensorAnalogConfigData(-250.0F, 250.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.001F, 0, UnitConversion::NO_CONVERSION);
 
     tInputVoltSensorInputData = SensorAnalogInputData(true, 0.0);
     tInputCurrentSensorInputData = SensorAnalogInputData(true, 0.0);

--- a/aspects/electrical/TripLogic/test/UtGunnsTripLogic.cpp
+++ b/aspects/electrical/TripLogic/test/UtGunnsTripLogic.cpp
@@ -66,7 +66,7 @@ void UtGunnsTripLogic::testConstruction()
         FriendlyGunnsTripGreaterThan* article = new FriendlyGunnsTripGreaterThan();
         CPPUNIT_ASSERT(false == article->mMalfInhibitTrip);
         CPPUNIT_ASSERT(false == article->mMalfForceTrip);
-        CPPUNIT_ASSERT(0.0   == article->mLimit);
+        CPPUNIT_ASSERT(0.0F  == article->mLimit);
         CPPUNIT_ASSERT(0     == article->mPriority);
         CPPUNIT_ASSERT(false == article->mIsTripped);
         delete article;
@@ -75,7 +75,7 @@ void UtGunnsTripLogic::testConstruction()
         FriendlyGunnsTripLessThan* article = new FriendlyGunnsTripLessThan();
         CPPUNIT_ASSERT(false == article->mMalfInhibitTrip);
         CPPUNIT_ASSERT(false == article->mMalfForceTrip);
-        CPPUNIT_ASSERT(0.0   == article->mLimit);
+        CPPUNIT_ASSERT(0.0F  == article->mLimit);
         CPPUNIT_ASSERT(0     == article->mPriority);
         CPPUNIT_ASSERT(false == article->mIsTripped);
         delete article;
@@ -140,32 +140,32 @@ void UtGunnsTripLogic::testCheckForTrip()
 
         /// @test    No trip condition and not priority yet.
         GunnsBasicLink::SolutionResult result = GunnsBasicLink::CONFIRM;
-        bool justTripped = article->checkForTrip(result, 4.9, 2);
+        bool justTripped = article->checkForTrip(result, 4.9F, 2);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
 
         /// @test    Trip condition but not priority yet.
-        justTripped = article->checkForTrip(result, 5.1, 2);
+        justTripped = article->checkForTrip(result, 5.1F, 2);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::DELAY   == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
 
         /// @test    Trip condition and priority met.
-        justTripped = article->checkForTrip(result, 5.1, 3);
+        justTripped = article->checkForTrip(result, 5.1F, 3);
         CPPUNIT_ASSERT(true                    == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::REJECT  == result);
         CPPUNIT_ASSERT(true                    == article->mIsTripped);
 
         /// @test    Trip condition and past priority.
-        justTripped = article->checkForTrip(result, 5.1, 4);
+        justTripped = article->checkForTrip(result, 5.1F, 4);
         result      = GunnsBasicLink::CONFIRM;
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(true                    == article->mIsTripped);
 
         /// @test    Tripped and priority met but no trip condition.
-        justTripped = article->checkForTrip(result, 4.9, 4);
+        justTripped = article->checkForTrip(result, 4.9F, 4);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(true                    == article->mIsTripped);
@@ -173,14 +173,14 @@ void UtGunnsTripLogic::testCheckForTrip()
         /// @test    Priority met but no trip condition.
         result      = GunnsBasicLink::CONFIRM;
         article->mIsTripped = false;
-        justTripped = article->checkForTrip(result, 4.9, 4);
+        justTripped = article->checkForTrip(result, 4.9F, 4);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
 
         /// @test    Trip condition, not priority yet, but result is already REJECT.
         result      = GunnsBasicLink::REJECT;
-        justTripped = article->checkForTrip(result, 5.1, 2);
+        justTripped = article->checkForTrip(result, 5.1F, 2);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::REJECT  == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
@@ -189,7 +189,7 @@ void UtGunnsTripLogic::testCheckForTrip()
         article->mIsTripped     = false;
         article->mMalfForceTrip = true;
         result                  = GunnsBasicLink::CONFIRM;
-        justTripped = article->checkForTrip(result, 4.9, 2);
+        justTripped = article->checkForTrip(result, 4.9F, 2);
         CPPUNIT_ASSERT(true                    == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::REJECT  == result);
         CPPUNIT_ASSERT(true                    == article->mIsTripped);
@@ -199,7 +199,7 @@ void UtGunnsTripLogic::testCheckForTrip()
         article->mMalfForceTrip   = true;
         article->mMalfInhibitTrip = true;
         result                    = GunnsBasicLink::CONFIRM;
-        justTripped = article->checkForTrip(result, 5.1, 3);
+        justTripped = article->checkForTrip(result, 5.1F, 3);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
@@ -210,7 +210,7 @@ void UtGunnsTripLogic::testCheckForTrip()
         article->mMalfInhibitTrip = false;
         article->mLimit           = 0.0;
         result                    = GunnsBasicLink::CONFIRM;
-        justTripped = article->checkForTrip(result, 5.1, 3);
+        justTripped = article->checkForTrip(result, 5.1F, 3);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
@@ -219,7 +219,7 @@ void UtGunnsTripLogic::testCheckForTrip()
         article->mLimit           = tLimit;
         article->mPriority        = 0;
         result                    = GunnsBasicLink::CONFIRM;
-        justTripped = article->checkForTrip(result, 5.1, 3);
+        justTripped = article->checkForTrip(result, 5.1F, 3);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
@@ -231,12 +231,12 @@ void UtGunnsTripLogic::testCheckForTrip()
         article->initialize(tLimit, tPriority, false);
 
         GunnsBasicLink::SolutionResult result = GunnsBasicLink::CONFIRM;
-        bool justTripped = article->checkForTrip(result, 5.1, 3);
+        bool justTripped = article->checkForTrip(result, 5.1F, 3);
         CPPUNIT_ASSERT(false                   == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::CONFIRM == result);
         CPPUNIT_ASSERT(false                   == article->mIsTripped);
 
-        justTripped = article->checkForTrip(result, 4.9, 3);
+        justTripped = article->checkForTrip(result, 4.9F, 3);
         CPPUNIT_ASSERT(true                    == justTripped);
         CPPUNIT_ASSERT(GunnsBasicLink::REJECT  == result);
         CPPUNIT_ASSERT(true                    == article->mIsTripped);

--- a/aspects/electrical/resistive/test/UtGunnsResistorPowerFunction.cpp
+++ b/aspects/electrical/resistive/test/UtGunnsResistorPowerFunction.cpp
@@ -324,7 +324,7 @@ void UtGunnsResistorPowerFunction::testStep()
         CPPUNIT_ASSERT(true == tArticle->needAdmittanceUpdate());
     } {
         /// @test    Potential below minimum linearization.
-        tArticle->mPotentialVector[tPort0] = tNodes[tPort1].getPotential() + FLT_EPSILON;
+        tArticle->mPotentialVector[tPort0] = tNodes[tPort1].getPotential() + static_cast<double>(FLT_EPSILON);
         tArticle->step(tTimeStep);
         const double dP        = minLinP;
         const double G         = 1.0 / tResistance;
@@ -387,7 +387,7 @@ void UtGunnsResistorPowerFunction::testStep()
         CPPUNIT_ASSERT(true == tArticle->needAdmittanceUpdate());
     } {
         /// @test    Potential below minimum linearization.
-        tArticle->mPotentialVector[tPort0] = tNodes[tPort1].getPotential() + FLT_EPSILON;
+        tArticle->mPotentialVector[tPort0] = tNodes[tPort1].getPotential() + static_cast<double>(FLT_EPSILON);
         tArticle->step(tTimeStep);
         const double dP        = minLinP;
         const double G         = 1.0 / tResistance;
@@ -553,7 +553,7 @@ void UtGunnsResistorPowerFunction::testInitializationExceptions()
     tConfigData->mResistance = tResistance;
 
     /// @test    Initialization exception on invalid config data: exponent near zero.
-    tConfigData->mExponent = FLT_EPSILON;
+    tConfigData->mExponent = static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());

--- a/aspects/electrical/sar/test/UtGunnsSolarArrayRegulator.cpp
+++ b/aspects/electrical/sar/test/UtGunnsSolarArrayRegulator.cpp
@@ -124,10 +124,10 @@ void UtGunnsSolarArrayRegulator::setUp()
     tRegulatedVoltageHighLimit         =  131.2;
 
     // sensor configuration/input
-    tOutVoltageUpperLimit              =  140.0;
-    tOutCurrentUpperLimit              =  125.0;
-    tOutVoltageNoiseScale              =   2.80;
-    tOutCurrentNoiseScale              =   3.75;
+    tOutVoltageUpperLimit              =  140.0F;
+    tOutCurrentUpperLimit              =  125.0F;
+    tOutVoltageNoiseScale              =   2.80F;
+    tOutCurrentNoiseScale              =   3.75F;
 
     // input data
     tmalfBlockageFlag                  =  false;
@@ -162,10 +162,10 @@ void UtGunnsSolarArrayRegulator::setUp()
     tTolerance          = 1.0e-08;
 
     // sensor config data
-    tOutVoltageSensorConfig = new SensorAnalogConfigData(0.0, tOutVoltageUpperLimit, 0.0, 0.0, 1.0, tOutVoltageNoiseScale,
-                                                         0.001, 0, UnitConversion::NO_CONVERSION);
-    tOutCurrentSensorConfig = new SensorAnalogConfigData(-125.0, tOutCurrentUpperLimit, 0.0, 0.0, 1.0, tOutCurrentNoiseScale,
-                                                         0.001, 0, UnitConversion::NO_CONVERSION);
+    tOutVoltageSensorConfig = new SensorAnalogConfigData(0.0F, tOutVoltageUpperLimit, 0.0F, 0.0F, 1.0F, tOutVoltageNoiseScale,
+                                                         0.001F, 0, UnitConversion::NO_CONVERSION);
+    tOutCurrentSensorConfig = new SensorAnalogConfigData(-125.0F, tOutCurrentUpperLimit, 0.0F, 0.0F, 1.0F, tOutCurrentNoiseScale,
+                                                         0.001F, 0, UnitConversion::NO_CONVERSION);
 
     // sensor input data
     tOutVoltageSensorInput  = new SensorAnalogInputData(true, 0.0);

--- a/aspects/fluid/capacitor/test/UtGunnsFluidAccumGas.cpp
+++ b/aspects/fluid/capacitor/test/UtGunnsFluidAccumGas.cpp
@@ -787,10 +787,11 @@ void UtGunnsFluidAccumGas::testPressureEdit()
     double originalBellowsPos = tModel->mBellowsPosition;
     double originalTemperature = tModel->mGasInternalFluid->getTemperature();
 
-    int numIterations = ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
+    int numIterations = static_cast<int>(
+                        ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
                           / tModel->mEditPressureRate                                                // number of seconds to achieve edit
                           + tModel->mEditHoldTime)                                                   // add edit hold time
-                          / tTimeStep                                                                // convert to iterations
+                          / tTimeStep)                                                               // convert to iterations
                           + 5;                                                                       // small pad at the end
 
     for (int i=0;i<numIterations;i++)
@@ -824,10 +825,11 @@ void UtGunnsFluidAccumGas::testPressureEdit()
     originalBellowsPos = tModel->mBellowsPosition;
     originalTemperature = tModel->mGasInternalFluid->getTemperature();
 
-    numIterations = ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
+    numIterations = static_cast<int>(
+                    ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
                       / tModel->mEditPressureRate                                                // number of seconds to achieve edit
                       + tModel->mEditHoldTime)                                                   // add edit hold time
-                      / tTimeStep                                                                // convert to iterations
+                      / tTimeStep)                                                               // convert to iterations
                       + 5;                                                                       // small pad at the end
 
     for (int i=0;i<numIterations;i++)
@@ -1007,10 +1009,11 @@ void UtGunnsFluidAccumGas::testBellowsEdit()
     double originalPressure = tModel->mInternalFluid->getPressure();
     double originalTemperature = tModel->mGasInternalFluid->getTemperature();
 
-    int numIterations = ((tModel->mEditBellowsPosition - tInputData->mInitialBellowsPosition) // Delta bellows pos to edit
+    int numIterations = static_cast<int>(
+                        ((tModel->mEditBellowsPosition - tInputData->mInitialBellowsPosition) // Delta bellows pos to edit
                           / tModel->mEditBellowsRate                                          // number of seconds to achieve edit
                           + tModel->mEditHoldTime)                                            // add edit hold time
-                          / tTimeStep                                                         // convert to iterations
+                          / tTimeStep)                                                        // convert to iterations
                           + 5;                                                                // A little pad at the end.
 
     for (int i=0;i<numIterations;i++)
@@ -1047,15 +1050,17 @@ void UtGunnsFluidAccumGas::testBellowsEdit()
     originalPressure = tModel->mGasInternalFluid->getPressure();
     originalTemperature = tModel->mGasInternalFluid->getTemperature();
 
-    int numIterationsPressure = ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
+    int numIterationsPressure = static_cast<int>(
+                                 ((tModel->mEditPressureValue - tInputData->mGasFluidInputData->mPressure)    // Delta pressure to edit
                                   / tModel->mEditPressureRate                                                 // number of seconds to achieve edit
                                   + tModel->mEditHoldTime)                                                    // add edit hold time
-                                  / tTimeStep;                                                                // convert to iterations
+                                  / tTimeStep);                                                               // convert to iterations
 
-    int numIterationsBellows = ((tModel->mEditBellowsPosition - tInputData->mInitialBellowsPosition) // Delta bellows pos to edit
+    int numIterationsBellows = static_cast<int>(
+                               ((tModel->mEditBellowsPosition - tInputData->mInitialBellowsPosition) // Delta bellows pos to edit
                                  / tModel->mEditBellowsRate                                          // number of seconds to achieve edit
                                  + tModel->mEditHoldTime)                                            // add edit hold time
-                                 / tTimeStep;                                                        // convert to iterations
+                                 / tTimeStep);                                                       // convert to iterations
 
     numIterations = numIterationsPressure + numIterationsBellows + 5;                                // Allow more than enough iterations.
 

--- a/aspects/fluid/capacitor/test/UtGunnsFluidBalloon.cpp
+++ b/aspects/fluid/capacitor/test/UtGunnsFluidBalloon.cpp
@@ -128,7 +128,7 @@ void UtGunnsFluidBalloon::setUp()
     tBiasHeatFlux         = 10.0;
     tInputData            = new GunnsFluidBalloonInputData(false, false, 0.0,
                                                            tFluidInputGas,
-                                                           tShellTemperature,
+                                                           static_cast<float>(tShellTemperature),
                                                            tBiasHeatFlux);
 
     /// - Define the nominal port mapping.
@@ -181,7 +181,7 @@ void UtGunnsFluidBalloon::testConfigAndInput()
 
     /// @test    Input data nominal construction.
     GunnsFluidBalloonInputData nominalInput(true, true, 1.0, tFluidInputGas,
-                                            tShellTemperature, tBiasHeatFlux);
+                                            static_cast<float>(tShellTemperature), tBiasHeatFlux);
     CPPUNIT_ASSERT(false                 == nominalInput.mMalfBlockageFlag);
     CPPUNIT_ASSERT(0.0                   == nominalInput.mMalfBlockageValue);
     CPPUNIT_ASSERT(true                  == nominalInput.mMalfStuckFlag);
@@ -189,7 +189,7 @@ void UtGunnsFluidBalloon::testConfigAndInput()
     CPPUNIT_ASSERT(1.0                   == nominalInput.mMalfInflatabilityScaleValue);
     CPPUNIT_ASSERT(tFluidInputGas        == nominalInput.mInitialFluidState);
     CPPUNIT_ASSERT(0.0                   == nominalInput.mInitialVolume);
-    CPPUNIT_ASSERT(tShellTemperature     == nominalInput.mShellTemperature);
+    CPPUNIT_ASSERT(tShellTemperature     == static_cast<double>(nominalInput.mShellTemperature));
     CPPUNIT_ASSERT(tBiasHeatFlux         == nominalInput.mBiasHeatFlux);
 
     /// @test    Configuration data default construction.
@@ -200,8 +200,8 @@ void UtGunnsFluidBalloon::testConfigAndInput()
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mDpdtFilterGain);
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mThermalDampingMass);
     CPPUNIT_ASSERT(1.0E-6                == defaultConfig.mEditFluxTarget);
-    CPPUNIT_ASSERT(0.0                   == defaultConfig.mSurfaceArea);
-    CPPUNIT_ASSERT(0.0                   == defaultConfig.mShellRadius);
+    CPPUNIT_ASSERT(0.0F                  == defaultConfig.mSurfaceArea);
+    CPPUNIT_ASSERT(0.0F                  == defaultConfig.mShellRadius);
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mInflatability);
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mMaxVolume);
 
@@ -214,8 +214,8 @@ void UtGunnsFluidBalloon::testConfigAndInput()
     CPPUNIT_ASSERT(0.0                   == defaultInput.mMalfInflatabilityScaleValue);
     CPPUNIT_ASSERT(0                     == defaultInput.mInitialFluidState);
     CPPUNIT_ASSERT(0.0                   == defaultInput.mInitialVolume);
-    CPPUNIT_ASSERT(0.0                   == defaultInput.mShellTemperature);
-    CPPUNIT_ASSERT(0.0                   == defaultInput.mBiasHeatFlux);
+    CPPUNIT_ASSERT(0.0F                  == defaultInput.mShellTemperature);
+    CPPUNIT_ASSERT(0.0F                  == defaultInput.mBiasHeatFlux);
 
     /// @test    Configuration data copy construction.
     GunnsFluidBalloonConfigData copyConfig(*tConfigData);
@@ -239,7 +239,7 @@ void UtGunnsFluidBalloon::testConfigAndInput()
     CPPUNIT_ASSERT(1.0                   == copyInput.mMalfInflatabilityScaleValue);
     CPPUNIT_ASSERT(tFluidInputGas        == copyInput.mInitialFluidState);
     CPPUNIT_ASSERT(0.0                   == copyInput.mInitialVolume);
-    CPPUNIT_ASSERT(tShellTemperature     == copyInput.mShellTemperature);
+    CPPUNIT_ASSERT(tShellTemperature     == static_cast<double>(copyInput.mShellTemperature));
     CPPUNIT_ASSERT(tBiasHeatFlux         == copyInput.mBiasHeatFlux);
 
     UT_PASS;
@@ -307,8 +307,8 @@ void UtGunnsFluidBalloon::testNominalInitialization()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->mNodes[0]->getVolume(), DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->getVolume(),            DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->mInflation,             FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),         FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->mInflation,             static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),         static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsFluidBalloon::INFLATING  == tArticle->mInflationState);
     CPPUNIT_ASSERT(GunnsFluidBalloon::INFLATING  == tArticle->getInflationState());
     CPPUNIT_ASSERT(0.0                           == tArticle->mPressureCorrection);
@@ -497,7 +497,7 @@ void UtGunnsFluidBalloon::testUpdateFluid()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->getVolume(),      DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tNodes[tPort0].getVolume(), DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsFluidBalloon::DEFLATING  == tArticle->getInflationState());
 
     /// @test    updateFluid when inflating.
@@ -513,7 +513,7 @@ void UtGunnsFluidBalloon::testUpdateFluid()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->getVolume(),      DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tNodes[tPort0].getVolume(), DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsFluidBalloon::INFLATING  == tArticle->getInflationState());
 
     /// @test    updateFluid when holding steady, partially inflated.
@@ -526,7 +526,7 @@ void UtGunnsFluidBalloon::testUpdateFluid()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->getVolume(),      DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tNodes[tPort0].getVolume(), DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsFluidBalloon::PARTIALLY_INFLATED  == tArticle->getInflationState());
 
     /// @test    updateFluid with the stuck malfunction active.
@@ -538,7 +538,7 @@ void UtGunnsFluidBalloon::testUpdateFluid()
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tArticle->getVolume(),      DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(volume,    tNodes[tPort0].getVolume(), DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(inflation, tArticle->getInflation(),   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(GunnsFluidBalloon::PARTIALLY_INFLATED  == tArticle->getInflationState());
 
     UT_PASS;
@@ -663,7 +663,7 @@ void UtGunnsFluidBalloon::testEditPartialPressureRate()
     double delMoles    = 1000.0 * delPressure * delVolume / RT;
     double mdot        = 2.0 * delMoles * tArticle->mInternalFluid->getMWeight() / tTimeStep;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(mdot, -tArticle->mFlowRate, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(mdot, -tArticle->mFlowRate, static_cast<double>(FLT_EPSILON));
 
     UT_PASS;
 }
@@ -695,14 +695,14 @@ void UtGunnsFluidBalloon::testPressureCorrectionPos()
     double linkG  = tArticle->mPressureCorrectionGain;
     double linkPc = nodePc * linkG;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-Perr,  linkPc,                        FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(linkPc, tArticle->mPressureCorrection, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-Perr,  linkPc,                        static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(linkPc, tArticle->mPressureCorrection, static_cast<double>(FLT_EPSILON));
 
     /// @test    pressure correction not applied when disabled.
     tArticle->mDisablePressureCorrection = true;
     tArticle->step(tTimeStep);
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, tArticle->mPressureCorrection, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, tArticle->mPressureCorrection, static_cast<double>(FLT_EPSILON));
 
     UT_PASS;
 }
@@ -734,8 +734,8 @@ void UtGunnsFluidBalloon::testPressureCorrectionNeg()
     double linkG  = tArticle->mPressureCorrectionGain;
     double linkPc = nodePc * linkG;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-Perr,  linkPc,                        FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(linkPc, tArticle->mPressureCorrection, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-Perr,  linkPc,                        static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(linkPc, tArticle->mPressureCorrection, static_cast<double>(FLT_EPSILON));
 
     UT_PASS;
 }

--- a/aspects/fluid/capacitor/test/UtGunnsFluidTank.cpp
+++ b/aspects/fluid/capacitor/test/UtGunnsFluidTank.cpp
@@ -117,7 +117,7 @@ void UtGunnsFluidTank::setUp()
     mInputData            = new GunnsFluidTankInputData(false, 0.0,
                                                         mVolume,
                                                         mFluidInput0,
-                                                        mShellTemperature,
+                                                        static_cast<float>(mShellTemperature),
                                                         mBiasHeatFlux);
 
     /// - Define the nominal port mapping.
@@ -171,7 +171,7 @@ void UtGunnsFluidTank::testConfigAndInput()
     /// @test    Input data nominal construction.
     CPPUNIT_ASSERT(mFluidInput0          == mInputData->mInitialFluidState);
     CPPUNIT_ASSERT(mVolume               == mInputData->mInitialVolume);
-    CPPUNIT_ASSERT(mShellTemperature     == mInputData->mShellTemperature);
+    CPPUNIT_ASSERT(mShellTemperature     == static_cast<double>(mInputData->mShellTemperature));
     CPPUNIT_ASSERT(mBiasHeatFlux         == mInputData->mBiasHeatFlux);
 
     /// @test    Configuration data default construction.
@@ -182,15 +182,15 @@ void UtGunnsFluidTank::testConfigAndInput()
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mDpdtFilterGain);
     CPPUNIT_ASSERT(0.0                   == defaultConfig.mThermalDampingMass);
     CPPUNIT_ASSERT(1.0E-6                == defaultConfig.mEditFluxTarget);
-    CPPUNIT_ASSERT(0.0                   == defaultConfig.mSurfaceArea);
-    CPPUNIT_ASSERT(0.0                   == defaultConfig.mShellRadius);
+    CPPUNIT_ASSERT(0.0F                  == defaultConfig.mSurfaceArea);
+    CPPUNIT_ASSERT(0.0F                  == defaultConfig.mShellRadius);
 
     /// @test    Input data default construction.
     GunnsFluidTankInputData defaultInput;
     CPPUNIT_ASSERT(0                     == defaultInput.mInitialFluidState);
     CPPUNIT_ASSERT(0.0                   == defaultInput.mInitialVolume);
-    CPPUNIT_ASSERT(0.0                   == defaultInput.mShellTemperature);
-    CPPUNIT_ASSERT(0.0                   == defaultInput.mBiasHeatFlux);
+    CPPUNIT_ASSERT(0.0F                  == defaultInput.mShellTemperature);
+    CPPUNIT_ASSERT(0.0F                  == defaultInput.mBiasHeatFlux);
 
     /// @test    Configuration data copy construction.
     GunnsFluidTankConfigData copyConfig(*mConfigData);
@@ -207,7 +207,7 @@ void UtGunnsFluidTank::testConfigAndInput()
     GunnsFluidTankInputData copyInput(*mInputData);
     CPPUNIT_ASSERT(mFluidInput0          == copyInput.mInitialFluidState);
     CPPUNIT_ASSERT(mVolume               == copyInput.mInitialVolume);
-    CPPUNIT_ASSERT(mShellTemperature     == copyInput.mShellTemperature);
+    CPPUNIT_ASSERT(mShellTemperature     == static_cast<double>(copyInput.mShellTemperature));
     CPPUNIT_ASSERT(mBiasHeatFlux         == copyInput.mBiasHeatFlux);
 
     UT_PASS;
@@ -329,7 +329,7 @@ void UtGunnsFluidTank::testAccessors()
     /// @test    Set up a heat flux from the tank shell, which will normally come from the sim bus,
     ///          and verify the getHeatFlux method.
     mArticle->mHeatFluxFromShell = 1.0;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0 + mBiasHeatFlux,     mArticle->getHeatFlux(), 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0 + static_cast<double>(mBiasHeatFlux),     mArticle->getHeatFlux(), 0.0);
 
     /// @test    Get Dpdt.
     mArticle->mDpdt = 4.0;
@@ -339,7 +339,7 @@ void UtGunnsFluidTank::testAccessors()
     double tempBiasHeatFlux = mArticle->mBiasHeatFlux;
     mArticle->mBiasHeatFlux = 2.0;
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0, mArticle->getBiasHeatFlux(),   0.0);
-    mArticle->mBiasHeatFlux = tempBiasHeatFlux;
+    mArticle->mBiasHeatFlux = static_cast<float>(tempBiasHeatFlux);
 
     /// @test    Get Partial Pressure.
     mArticle->mPartialPressure[0] = 5.0;
@@ -350,66 +350,66 @@ void UtGunnsFluidTank::testAccessors()
     /// @test    Set temperature edit.
     mArticle->editTemperature(true, 290.0);
     CPPUNIT_ASSERT(true  == mArticle->mEditTemperatureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, static_cast<double>(FLT_EPSILON));
 
     /// @test    Reset temperature edit.
     mArticle->editTemperature();
     CPPUNIT_ASSERT(false == mArticle->mEditTemperatureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, static_cast<double>(FLT_EPSILON));
 
     /// @test    Set temperature and total pressure edit.
     mArticle->editTemperaturePressure(true, 290.0, 90.0);
     CPPUNIT_ASSERT(true  == mArticle->mEditTemperaturePressureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 90.0, mArticle->mEditPressureValue,    FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 90.0, mArticle->mEditPressureValue,    static_cast<double>(FLT_EPSILON));
 
     /// @test    Reset temperature and total pressure edit.
     mArticle->editTemperaturePressure();
     CPPUNIT_ASSERT(false == mArticle->mEditTemperaturePressureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 90.0, mArticle->mEditPressureValue,    FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue, static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 90.0, mArticle->mEditPressureValue,    static_cast<double>(FLT_EPSILON));
 
     /// @test    Set temperature and partial pressures edit.
     double pp[N_FLUIDS] = {70.0, 30.0};
     mArticle->editTemperaturePartialPressure(true, 290.0, pp);
     CPPUNIT_ASSERT(true  == mArticle->mEditTemperaturePartialPressureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Reset temperature and partial pressures edit.
     mArticle->editTemperaturePartialPressure();
     CPPUNIT_ASSERT(false == mArticle->mEditTemperaturePartialPressureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Temperature & partial pressures edit method does nothing to the temperature if no
     ///          value is supplied, and nothing to the partial pressures if no partial pressure
     ///          array is supplied.
     mArticle->editTemperaturePartialPressure(true, 0.0, 0);
     CPPUNIT_ASSERT(true  == mArticle->mEditTemperaturePartialPressureFlag);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(290.0, mArticle->mEditTemperatureValue,        static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[0], static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 30.0, mArticle->mEditPartialPressureValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Set partial pressure rates edit.
     mArticle->editPartialPressureRate(FluidProperties::GUNNS_O2, true, 70.0, 1.0);
     CPPUNIT_ASSERT(true  == mArticle->mEditPartialPressureRateFlag[1]);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Partial pressure rate edit method does nothing if no constituent supplied.
     mArticle->editPartialPressureRate();
     CPPUNIT_ASSERT(true  == mArticle->mEditPartialPressureRateFlag[1]);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Reset partial pressure rates edit for the constituent.
     mArticle->editPartialPressureRate(FluidProperties::GUNNS_O2);
     CPPUNIT_ASSERT(false == mArticle->mEditPartialPressureRateFlag[1]);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL( 70.0, mArticle->mEditPartialPressureValue[1],     static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(  1.0, mArticle->mEditPartialPressureRateValue[1], static_cast<double>(FLT_EPSILON));
 
     /// @test    Exception thrown on invalid fluid type arg to partial pressure rate edit.
     CPPUNIT_ASSERT_THROW(mArticle->editPartialPressureRate(FluidProperties::GUNNS_AMMONIA),
@@ -750,7 +750,7 @@ void UtGunnsFluidTank::testEditPartialPressureRate()
     double targetPartialPressure               = mArticle->mNodes[0]->getContent()->
                                                  getPartialPressure(FluidProperties::GUNNS_O2) +
                                                  mArticle->mEditPartialPressureRateValue[1] *
-                                                 mTimeStep + FLT_EPSILON;
+                                                 mTimeStep + static_cast<double>(FLT_EPSILON);
     mArticle->mEditPartialPressureValue[1]     = targetPartialPressure;
     mArticle->mEditPartialPressureRateFlag[1]  = true;
 
@@ -773,13 +773,13 @@ void UtGunnsFluidTank::testEditPartialPressureRate()
                         - expectedMdot / expectedMW;
 
     /// @test    Check outputs.
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(283.0, mArticle->mInternalFluid->getTemperature(),  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, mArticle->mInternalFluid->getMWeight(), FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMdot, mArticle->mFlowRate,                  FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(283.0, mArticle->mInternalFluid->getTemperature(),  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, mArticle->mInternalFluid->getMWeight(), static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMdot, mArticle->mFlowRate,                  static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,   mNodes[0].mExpansionScaleFactor,             0.0);
     CPPUNIT_ASSERT(true == mArticle->mEditPartialPressureRateFlag[1]);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, mArticle->mSourceVector[0],           FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,          mArticle->mSourceVector[1],           FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFlux, mArticle->mSourceVector[0],           static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,          mArticle->mSourceVector[1],           static_cast<double>(FLT_EPSILON));
 
     // - Mimic the remaining steps that the Gunns solver will take prior to the next pass through
     //   our test article.
@@ -812,7 +812,7 @@ void UtGunnsFluidTank::testEditPartialPressureRate()
     targetPartialPressure                      = mArticle->mNodes[0]->getContent()->
                                                  getPartialPressure(FluidProperties::GUNNS_N2) -
                                                  mArticle->mEditPartialPressureRateValue[0] *
-                                                 mTimeStep - FLT_EPSILON;
+                                                 mTimeStep - static_cast<double>(FLT_EPSILON);
     mArticle->mEditPartialPressureValue[0]     = targetPartialPressure;
     mArticle->mEditPartialPressureRateFlag[0]  = true;
 
@@ -824,9 +824,9 @@ void UtGunnsFluidTank::testEditPartialPressureRate()
     mArticle->step(mTimeStep);
 
     /// @test    Check outputs.
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(283.0, mArticle->mInternalFluid->getTemperature(),  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, mArticle->mInternalFluid->getMWeight(), FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMdot, mArticle->mFlowRate,                  FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(283.0, mArticle->mInternalFluid->getTemperature(),  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, mArticle->mInternalFluid->getMWeight(), static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMdot, mArticle->mFlowRate,                  static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,   mNodes[0].mExpansionScaleFactor,             0.0);
     CPPUNIT_ASSERT(true == mArticle->mEditPartialPressureRateFlag[0]);
 
@@ -913,13 +913,13 @@ void UtGunnsFluidTank::testInitializationExceptions()
     mConfigData->mEditFluxTarget = mEditFluxTarget;
 
     /// @test    Initialization exception on surface area < 0.
-    mConfigData->mSurfaceArea = -0.01;
+    mConfigData->mSurfaceArea = -0.01F;
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mSurfaceArea = mSurfaceArea;
 
     /// @test    Initialization exception on shell radius < 0.
-    mConfigData->mShellRadius = -0.01;
+    mConfigData->mShellRadius = -0.01F;
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mShellRadius = mShellRadius;
@@ -932,10 +932,10 @@ void UtGunnsFluidTank::testInitializationExceptions()
     mInputData->mInitialFluidState = mFluidInput0;
 
     /// @test    Initialization exception on shell temperature < 0.
-    mInputData->mShellTemperature = -0.01;
+    mInputData->mShellTemperature = -0.01F;
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
-    mInputData->mShellTemperature = mShellTemperature;
+    mInputData->mShellTemperature = static_cast<float>(mShellTemperature);
 
     UT_PASS;
 }
@@ -1035,9 +1035,9 @@ void UtGunnsFluidTank::testOwnShellFlux()
     /// - Initialize default test article with nominal initialization data.
     /// - Shell radius = (3/4 * V/pi)^1/3.  We hard-code the pi product as a redundant check on the
     ///   pi constant used by the test article.
-    mShellRadius = std::pow(2.35619449019 * mVolume, (1.0/3.0));
+    mShellRadius = static_cast<float>(std::pow(2.35619449019 * mVolume, (1.0/3.0)));
     /// - Shell surface area = 4 pi r^2
-    mSurfaceArea = 12.5663706144 * mShellRadius* mShellRadius;
+    mSurfaceArea = 12.5663706144F * mShellRadius* mShellRadius;
     mConfigData->mShellRadius = mShellRadius;
     mConfigData->mSurfaceArea = mSurfaceArea;
     mInputData->mBiasHeatFlux = 0.0;
@@ -1047,8 +1047,8 @@ void UtGunnsFluidTank::testOwnShellFlux()
     mArticle->computeFlows(0.0);
     mArticle->transportFlows(0.0);
 
-    const double expectedFlux = mSurfaceArea * mNodes[0].getContent()->getThermalConductivity() *
-            (mShellTemperature - mFluidInput0->mTemperature) / mShellRadius;
+    const double expectedFlux = static_cast<double>(mSurfaceArea) * mNodes[0].getContent()->getThermalConductivity() *
+            (mShellTemperature - mFluidInput0->mTemperature) / static_cast<double>(mShellRadius);
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL( expectedFlux, mArticle->getHeatFlux(),     1.0E-6);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedFlux, mArticle->mHeatFluxToShell,  1.0E-6);
@@ -1076,8 +1076,8 @@ void UtGunnsFluidTank::testModifiers()
     mArticle->initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(mBiasHeatFlux, mArticle->mBiasHeatFlux, 1.0E-6);
 
-    mArticle->setBiasHeatFlux(mBiasHeatFlux + 2.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(mBiasHeatFlux + 2.0, mArticle->mBiasHeatFlux, 1.0E-6);
+    mArticle->setBiasHeatFlux(mBiasHeatFlux + 2.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(mBiasHeatFlux + 2.0F, mArticle->mBiasHeatFlux, 1.0E-6F);
 
     UT_PASS_LAST;
 }

--- a/aspects/fluid/conductor/test/UtGunnsFluidBalancedPrv.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidBalancedPrv.cpp
@@ -505,13 +505,13 @@ void UtGunnsFluidBalancedPrv::testStepEdgeCases()
     /// @test  Limited lower value of exit pressure droop.
     tArticle->mExitPressureDroop = 0.0;
     tArticle->step(0.01);
-    double expectedOutG = 1.0 / FLT_EPSILON / tNodes[tPort0].getOutflow()->getMWeight();
+    double expectedOutG = 1.0 / static_cast<double>(FLT_EPSILON) / tNodes[tPort0].getOutflow()->getMWeight();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedOutG, tArticle->mExitConductance, DBL_EPSILON);
 
     /// @test  Limited upper value of exit pressure droop.
     tArticle->mExitPressureDroop = 1.0e15;
     tArticle->step(0.01);
-    expectedOutG = 1.0 * FLT_EPSILON / tNodes[tPort0].getOutflow()->getMWeight();
+    expectedOutG = 1.0 * static_cast<double>(FLT_EPSILON) / tNodes[tPort0].getOutflow()->getMWeight();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedOutG, tArticle->mExitConductance, DBL_EPSILON);
 
     /// @test  Link port mapping and protect against zero inlet molecular weight.
@@ -571,7 +571,7 @@ void UtGunnsFluidBalancedPrv::testComputeFlows()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedInMdot,  tNodes[0].getOutflux(),     DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedOutMdot, tNodes[1].getInflux(),      DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tNodes[1].getInflow()->getMWeight(),
-                                 tNodes[0].getOutflow()->getMWeight(),        FLT_EPSILON);
+                                 tNodes[0].getOutflow()->getMWeight(),        static_cast<double>(FLT_EPSILON));
 
     /// @test  Verify correct port directions
     tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1, tPort2);

--- a/aspects/fluid/conductor/test/UtGunnsFluidCheckValve.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidCheckValve.cpp
@@ -618,7 +618,7 @@ void UtGunnsFluidCheckValve::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid config data: mRateLimit < 0.
-    mConfigData->mRateLimit  = -FLT_EPSILON;
+    mConfigData->mRateLimit  = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mRateLimit  = mRateLimit;
@@ -632,43 +632,43 @@ void UtGunnsFluidCheckValve::testInitializationExceptions()
     mConfigData->mOpenPressure   = mOpenPressure;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: wall temperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue < 0.
-    mInputData->mMalfFailToValue = -FLT_EPSILON;
+    mInputData->mMalfFailToValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue > 1.
-    mInputData->mMalfFailToValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfFailToValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidHatch.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidHatch.cpp
@@ -1008,39 +1008,39 @@ void UtGunnsFluidHatch::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid config data: mLength0 + mLength1 < FLT_EPSILON.
-    mConfigData->mLength0  = 0.25 * FLT_EPSILON;
-    mConfigData->mLength1  = 0.25 * FLT_EPSILON;
+    mConfigData->mLength0  = 0.25 * static_cast<double>(FLT_EPSILON);
+    mConfigData->mLength1  = 0.25 * static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mLength0  = mLength0;
     mConfigData->mLength1  = mLength1;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakThruValue < 0.
-    mInputData->mMalfLeakThruValue = -FLT_EPSILON;
+    mInputData->mMalfLeakThruValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfLeakThruValue = mMalfLeakThruValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidHeatExchanger.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidHeatExchanger.cpp
@@ -571,13 +571,13 @@ void UtGunnsFluidHeatExchanger::testInitializationExceptions()
     mConfigData->mNumSegs = mNumSegs;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidHxDynHtc.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidHxDynHtc.cpp
@@ -353,7 +353,7 @@ void UtGunnsFluidHxDynHtc::testHtc()
 
     /// @test    Test segment heat transfer coefficients with no malfunction.
     double mdot            = 2.0;
-    double expectedHtc     = (tHtcCoeff0 + tHtcCoeff1 * std::pow(mdot, tHtcExponent)) / tNumSegs;
+    double expectedHtc     = (tHtcCoeff0 + tHtcCoeff1 * std::pow(mdot, tHtcExponent)) / static_cast<double>(tNumSegs);
     tArticle->mMalfHxDegradeFlag = false;
     tArticle->mFlowRate          = mdot;
     tArticle->computeHeatTransferCoefficient();

--- a/aspects/fluid/conductor/test/UtGunnsFluidLeak.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidLeak.cpp
@@ -557,25 +557,25 @@ void UtGunnsFluidLeak::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakRateValue < 0.
-    mInputData->mMalfLeakHoleValue = -FLT_EPSILON;
+    mInputData->mMalfLeakHoleValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfLeakHoleValue = mMalfLeakHoleValue;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakRateValue < 0.
-    mInputData->mMalfLeakRateValue = -FLT_EPSILON;
+    mInputData->mMalfLeakRateValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfLeakRateValue = mMalfLeakRateValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidPipe.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidPipe.cpp
@@ -435,17 +435,17 @@ void UtGunnsFluidPipe::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid input data: blockage < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: blockage > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: pipe temperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1), TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;
 

--- a/aspects/fluid/conductor/test/UtGunnsFluidPressureSensitiveValve.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidPressureSensitiveValve.cpp
@@ -940,9 +940,9 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5 * defaultConductivity, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5 * defaultConductivity, mArticle->mMaxConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     /// - Tune the link to double its default true volumetric flow rate for positive flow.
     double defaultVdot     = mArticle->mFlowRate / mNodes[0].getOutflow()->getDensity();
@@ -951,9 +951,9 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0 * defaultConductivity, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0 * defaultConductivity, mArticle->mMaxConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     /// - Set up the nodes to create backflow and re-adjust the link to the new pressures.
     mNodes[0].setPotential(675.0);
@@ -972,9 +972,9 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5 * defaultConductivity, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5 * defaultConductivity, mArticle->mMaxConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     /// - Restore the nodes to their original state and re-adjust the link again.
     mNodes[0].setPotential(700.728);
@@ -994,9 +994,9 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0 * defaultConductivity, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.0 * defaultConductivity, mArticle->mMaxConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     /// - Tune the link to half its default expansion scale factor.
     const double defaultdT = mArticle->mNodes[1]->getOutflow()->getTemperature() -
@@ -1007,7 +1007,7 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.5 * defaultScaleFactor,  mArticle->mExpansionScaleFactor,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     const double expected    = mArticle->mEffectiveConductivity;
 
@@ -1015,13 +1015,13 @@ void UtGunnsFluidPressureSensitiveValve::testTuning()
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     mArticle->mTuneMode      = static_cast<GunnsFluidUtils::TuningMode>(-1);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT(GunnsFluidUtils::OFF == mArticle->mTuneMode);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->mEffectiveConductivity,
-                                                            FLT_EPSILON);
+                                                            static_cast<double>(FLT_EPSILON));
 
     UT_PASS;
 }
@@ -1191,43 +1191,43 @@ void UtGunnsFluidPressureSensitiveValve::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakThruValue < 0.
-    mInputData->mMalfLeakThruValue = -FLT_EPSILON;
+    mInputData->mMalfLeakThruValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfLeakThruValue = mMalfLeakThruValue;
 
     /// @test    Initialization exception on invalid input data: mWallTemperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue < 0.
-    mInputData->mMalfFailToValue = -FLT_EPSILON;
+    mInputData->mMalfFailToValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue > 1.
-    mInputData->mMalfFailToValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfFailToValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidRegulatorValve.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidRegulatorValve.cpp
@@ -647,13 +647,13 @@ void UtGunnsFluidRegulatorValve::testUpdateStateNominal()
     mArticle->mPotentialVector[3]   = 0.0;
 
     /// @test    Start above crack pressure so valve is closed.
-    mArticle->mPotentialVector[2]   = mCrackPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mCrackPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
 
     /// @test    Decrement to just below crack pressure so valve is closed but opening.
-    mArticle->mPotentialVector[2]   = mCrackPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mCrackPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
@@ -665,13 +665,13 @@ void UtGunnsFluidRegulatorValve::testUpdateStateNominal()
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
 
     /// @test    Decrement to just above full open pressure so valve is opening and almost open.
-    mArticle->mPotentialVector[2]   = mFullOpenPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mFullOpenPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
 
     /// @test    Decrement to just below full open pressure so valve is open.
-    mArticle->mPotentialVector[2]   = mFullOpenPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mFullOpenPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::OPEN == mArticle->mState);
@@ -683,13 +683,13 @@ void UtGunnsFluidRegulatorValve::testUpdateStateNominal()
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSING == mArticle->mState);
 
     /// @test    Increment to just below reseat pressure so valve is closing and almost closed.
-    mArticle->mPotentialVector[2]   = mReseatPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mReseatPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSING == mArticle->mState);
 
     /// @test    Increment to just above reseat pressure so valve is closed.
-    mArticle->mPotentialVector[2]   = mReseatPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mReseatPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
@@ -725,7 +725,7 @@ void UtGunnsFluidRegulatorValve::testUpdateStateHysteresis()
     mArticle->mPotentialVector[3]   = 0.0;
 
     /// @test    Start above crack pressure so valve is closed.
-    mArticle->mPotentialVector[2]   = mCrackPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = mCrackPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
@@ -948,12 +948,12 @@ void UtGunnsFluidRegulatorValve::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid config data: mRateLimit < 0.
-    mConfigData->mRateLimit  = -FLT_EPSILON;
+    mConfigData->mRateLimit  = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mConfigData->mRateLimit  = mRateLimit;
 
     /// @test    Initialization exception on invalid config data: mFullOpenPressure < 0.
-    mConfigData->mFullOpenPressure  = -FLT_EPSILON;
+    mConfigData->mFullOpenPressure  = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mConfigData->mFullOpenPressure  = mFullOpenPressure;
 
@@ -985,43 +985,43 @@ void UtGunnsFluidRegulatorValve::testInitializationExceptions()
     mConfigData->mPopSlopeScale  = mPopSlopeScale;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakThruValue < 0.
-    mInputData->mMalfLeakThruValue = -FLT_EPSILON;
+    mInputData->mMalfLeakThruValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfLeakThruValue = mMalfLeakThruValue;
 
     /// @test    Initialization exception on invalid input data: mWallTemperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue < 0.
-    mInputData->mMalfFailToValue = -FLT_EPSILON;
+    mInputData->mMalfFailToValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue > 1.
-    mInputData->mMalfFailToValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfFailToValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidReliefValve.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidReliefValve.cpp
@@ -635,13 +635,13 @@ void UtGunnsFluidReliefValve::testUpdateStateNominal()
     mArticle->mRateLimit = 1.0 / mTimeStep;
 
     /// @test    Start at crack pressure so valve is closed.
-    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
 
     /// @test    Increment to just above crack pressure so valve is closed but opening.
-    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
@@ -653,13 +653,13 @@ void UtGunnsFluidReliefValve::testUpdateStateNominal()
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
 
     /// @test    Increment to just below full open pressure so valve is opening and almost open.
-    mArticle->mPotentialVector[2]   = outletPressure + mFullOpenPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mFullOpenPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::OPENING == mArticle->mState);
 
     /// @test    Increment to just above full open pressure so valve is open.
-    mArticle->mPotentialVector[2]   = outletPressure + mFullOpenPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mFullOpenPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::OPEN == mArticle->mState);
@@ -671,13 +671,13 @@ void UtGunnsFluidReliefValve::testUpdateStateNominal()
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSING == mArticle->mState);
 
     /// @test    Decrement to just above reseat pressure so valve is closing and almost closed.
-    mArticle->mPotentialVector[2]   = outletPressure + mReseatPressure + FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mReseatPressure + static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance * 1.0e+05);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSING == mArticle->mState);
 
     /// @test    Decrement to just below reseat pressure so valve is closed.
-    mArticle->mPotentialVector[2]   = outletPressure + mReseatPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mReseatPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
@@ -710,7 +710,7 @@ void UtGunnsFluidReliefValve::testUpdateStateHysteresis()
     mArticle->mRateLimit = 1.0 / mTimeStep;
 
     /// @test    Start just below crack pressure so valve is closed
-    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure - FLT_EPSILON;
+    mArticle->mPotentialVector[2]   = outletPressure + mCrackPressure - static_cast<double>(FLT_EPSILON);
     mArticle->step(mTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, mArticle->mPosition, mTolerance);
     CPPUNIT_ASSERT(GunnsFluidValve::CLOSED == mArticle->mState);
@@ -935,12 +935,12 @@ void UtGunnsFluidReliefValve::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid config data: mRateLimit < 0.
-    mConfigData->mRateLimit  = -FLT_EPSILON;
+    mConfigData->mRateLimit  = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mConfigData->mRateLimit  = mRateLimit;
 
     /// @test    Initialization exception on invalid config data: mReseatPressure < 0.
-    mConfigData->mReseatPressure  = -FLT_EPSILON;
+    mConfigData->mReseatPressure  = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mConfigData->mReseatPressure  = mReseatPressure;
 
@@ -971,43 +971,43 @@ void UtGunnsFluidReliefValve::testInitializationExceptions()
     mConfigData->mPopSlopeScale  = mPopSlopeScale;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakThruValue < 0.
-    mInputData->mMalfLeakThruValue = -FLT_EPSILON;
+    mInputData->mMalfLeakThruValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mMalfLeakThruValue = mMalfLeakThruValue;
 
     /// @test    Initialization exception on invalid input data: mWallTemperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3), TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue < 0.
-    mInputData->mMalfFailToValue = -FLT_EPSILON;
+    mInputData->mMalfFailToValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;
 
     /// @test    Initialization exception on invalid input data: mMalfFailToValue > 1.
-    mInputData->mMalfFailToValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfFailToValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1, mPort2, mPort3),
                          TsInitializationException);
     mInputData->mMalfFailToValue = mMalfFailToValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidSensor.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidSensor.cpp
@@ -422,13 +422,13 @@ void UtGunnsFluidSensor::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;

--- a/aspects/fluid/conductor/test/UtGunnsFluidSimpleRocket.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidSimpleRocket.cpp
@@ -355,7 +355,7 @@ void UtGunnsFluidSimpleRocket::testNominalInitialization()
     const double expectedG  = 1000.0 * tThroatArea / tCharacteristicVelocity;
     const double expectedMW = 21.87156537;
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedG,  tArticle->mDefaultConductance, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, tArticle->mCombustionMWeight,  FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, tArticle->mCombustionMWeight,  static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(0                      == tArticle->mCombustModel);
 
     /// @test    Nominal input data.
@@ -413,7 +413,7 @@ void UtGunnsFluidSimpleRocket::testCombustionInitialization()
     const double expectedG  = 1000.0 * tThroatArea / tCharacteristicVelocity;
     const double expectedMW = 21.87156537;
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedG,  tArticle->mDefaultConductance, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, tArticle->mCombustionMWeight,  FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMW, tArticle->mCombustionMWeight,  static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(0                      != tArticle->mCombustModel);
 
     /// @test    Nominal input data.
@@ -593,7 +593,7 @@ void UtGunnsFluidSimpleRocket::testStep()
     CPPUNIT_ASSERT(false == tArticle->mAdmittanceUpdate);
 
     /// @test   negative pressure gradient.
-    tArticle->mPotentialVector[0] = tNodes[1].getOutflow()->getPressure() - FLT_EPSILON;
+    tArticle->mPotentialVector[0] = tNodes[1].getOutflow()->getPressure() - static_cast<double>(FLT_EPSILON);
     tArticle->mAdmittanceUpdate = false;
     tArticle->step(0.01);
 

--- a/aspects/fluid/conductor/test/UtGunnsFluidValve.cpp
+++ b/aspects/fluid/conductor/test/UtGunnsFluidValve.cpp
@@ -780,31 +780,31 @@ void UtGunnsFluidValve::testInitializationExceptions()
     mConfigData->mExpansionScaleFactor = mExpansionScaleFactor;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mMalfBlockageValue > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mPosition < 0.
-    mInputData->mPosition = -FLT_EPSILON;
+    mInputData->mPosition = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mPosition > 1.
-    mInputData->mPosition = 1.0 + FLT_EPSILON;
+    mInputData->mPosition = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mPosition = mPosition;
 
     /// @test    Initialization exception on invalid input data: mMalfLeakThruValue < 0.
-    mInputData->mMalfLeakThruValue = -FLT_EPSILON;
+    mInputData->mMalfLeakThruValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfLeakThruValue = mMalfLeakThruValue;

--- a/aspects/fluid/fluid/test/UtMonoFluid.cpp
+++ b/aspects/fluid/fluid/test/UtMonoFluid.cpp
@@ -533,12 +533,12 @@ void UtMonoFluid::testConstructionExceptions()
             TsInitializationException);
     } {
         /// @test constructor for exception on temperature too small
-        MonoFluidInputData initData(FLT_EPSILON / 2.0, mPressure, mFlowRate, mMass);
+        MonoFluidInputData initData(static_cast<double>(FLT_EPSILON) / 2.0, mPressure, mFlowRate, mMass);
         CPPUNIT_ASSERT_THROW(new FriendlyMonoFluid(mProperties->getProperties(mType), initData),
             TsInitializationException);
     } {
         /// @test constructor for exception on pressure too small
-        MonoFluidInputData initData(mTemperature, FLT_EPSILON / 2.0, mFlowRate, mMass);
+        MonoFluidInputData initData(mTemperature, static_cast<double>(FLT_EPSILON) / 2.0, mFlowRate, mMass);
         CPPUNIT_ASSERT_THROW(new FriendlyMonoFluid(mProperties->getProperties(mType), initData),
             TsInitializationException);
     }
@@ -561,12 +561,12 @@ void UtMonoFluid::testInitializationExceptions()
             TsInitializationException);
     } {
         /// @test initialize for exception on temperature too small
-        MonoFluidInputData initData(FLT_EPSILON / 2.0, mPressure, mFlowRate, mMass);
+        MonoFluidInputData initData(static_cast<double>(FLT_EPSILON) / 2.0, mPressure, mFlowRate, mMass);
         FriendlyMonoFluid article;
         CPPUNIT_ASSERT_THROW(article.initialize(mProperties->getProperties(mType), initData), TsInitializationException);
     } {
         /// @test initialize for exception on pressure too small
-        MonoFluidInputData initData(mTemperature, FLT_EPSILON / 2.0, mFlowRate, mMass);
+        MonoFluidInputData initData(mTemperature, static_cast<double>(FLT_EPSILON) / 2.0, mFlowRate, mMass);
         FriendlyMonoFluid article;
         CPPUNIT_ASSERT_THROW(article.initialize(mProperties->getProperties(mType), initData), TsInitializationException);
     }

--- a/aspects/fluid/potential/test/UtGunnsGasFan.cpp
+++ b/aspects/fluid/potential/test/UtGunnsGasFan.cpp
@@ -415,7 +415,7 @@ void UtGunnsGasFan::testNominalInitialization()
 
     const double expectedPbep = 1000.0 * pressureBep * tReferenceQBep / tBestEfficiency;
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedPbep,   article.mReferencePowerBep,  1E-4);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(tReferenceQ,    article.mReferenceQ,         FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(tReferenceQ,    article.mReferenceQ,         static_cast<double>(FLT_EPSILON));
 
     /// @test    Terms initialized from input data.
     CPPUNIT_ASSERT(tMotorSpeed        == article.mMotorSpeed);
@@ -423,7 +423,7 @@ void UtGunnsGasFan::testNominalInitialization()
 
     /// @test    Initialized state data.
     const double expectedSysG = tReferenceQ / std::sqrt(tReferenceCoeff0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSysG, article.mSystemConstant, FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSysG, article.mSystemConstant, static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(0.0 == article.mWallHeatFlux);
     CPPUNIT_ASSERT(0.0 == article.mImpellerTorque);
     CPPUNIT_ASSERT(0.0 == article.mImpellerSpeed);
@@ -597,7 +597,7 @@ void UtGunnsGasFan::testInitializationExceptions()
     tConfigData->mReferenceQBep   = 0.0;
 
     /// @test    Initialization exception on invalid input data: mBlockage < 0.
-    tInputData->mMalfBlockageValue = -FLT_EPSILON;
+    tInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mMalfBlockageValue = tBlockage;
@@ -731,7 +731,7 @@ void UtGunnsGasFan::testUpdateState()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedCoeff0,        tArticle->mAffinityCoeffs[0], DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedCoeff2,        tArticle->mAffinityCoeffs[2], DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSystemConst,   tArticle->mSystemConstant,    DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceQ,       tArticle->mSourceQ,           FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceQ,       tArticle->mSourceQ,           static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceP,       tArticle->mSourcePressure,    0.000001);
 
     /// @test    Outputs at free-flow condition (max flow rate, zero pressure).
@@ -740,7 +740,7 @@ void UtGunnsGasFan::testUpdateState()
     tArticle->updateState(tTimeStep);
     expectedSourceQ           = tReferenceQ * expectedSpeedFactor;
     expectedSourceP           = 0.0;
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceQ,       tArticle->mSourceQ,           FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceQ,       tArticle->mSourceQ,           static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceP,       tArticle->mSourcePressure,    0.000001);
 
     /// @test    Outputs at dead-head condition (zero flow rate, max pressure).
@@ -754,7 +754,7 @@ void UtGunnsGasFan::testUpdateState()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSourceP,       tArticle->mSourcePressure,    0.01);
 
     /// @test    Outputs when fluid density near zero.
-    tNodes[0].getContent()->setPressure(FLT_EPSILON * 0.1);
+    tNodes[0].getContent()->setPressure(static_cast<double>(FLT_EPSILON) * 0.1);
     tNodes[0].resetFlows();
     tArticle->mVolFlowRate    = 0.06;
     tArticle->updateState(tTimeStep);

--- a/aspects/fluid/source/test/UtGunnsFluidAdsorber.cpp
+++ b/aspects/fluid/source/test/UtGunnsFluidAdsorber.cpp
@@ -477,7 +477,7 @@ void UtGunnsFluidAdsorber::testNominalInitializationNoTc()
     nodes[1].initialize("UtNode2", mFluidConfig);
     nodes[0].getContent()->initialize(*mFluidConfig, *mFluidInput0);
     nodes[1].getContent()->initialize(*mFluidConfig, *mFluidInput0);
-    
+
     nodes[0].resetFlows();
     nodes[1].resetFlows();
 
@@ -891,55 +891,55 @@ void UtGunnsFluidAdsorber::testInitializationExceptions()
     mConfigData->mGasType = FluidProperties::GUNNS_CO2;
 
     /// @test    Initialization exception on invalid config data: adsorption efficiency < 0.0.
-    mConfigData->mEfficiency = -FLT_EPSILON;
+    mConfigData->mEfficiency = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mEfficiency = mEfficiency;
 
     /// @test    Initialization exception on invalid config data: adsorption efficiency > 1.0.
-    mConfigData->mEfficiency = 1.0 + FLT_EPSILON;
+    mConfigData->mEfficiency = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mEfficiency = mEfficiency;
 
     /// @test    Initialization exception on invalid config data: maximum adsorbed mass < 0.0.
-    mConfigData->mMaxAdsorbtionRate = -FLT_EPSILON;
+    mConfigData->mMaxAdsorbtionRate = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mMaxAdsorbtionRate = mMaxAdsorbtionRate;
 
     /// @test    Initialization exception on invalid config data: maximum adsorption rate < 0.0.
-    mConfigData->mMaxAdsorbedMass = -FLT_EPSILON;
+    mConfigData->mMaxAdsorbedMass = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mMaxAdsorbedMass = mMaxAdsorbedMass;
 
-    /// @test    Initialization exception on invalid config data: desorbtion rate < 0.0.
-    mConfigData->mDesorbtionRate = -FLT_EPSILON;
+    /// @test    Initialization exception on invalid config data: desorption rate < 0.0.
+    mConfigData->mDesorbtionRate = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mDesorbtionRate = mDesorbtionRate;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mass in adsorber < 0.
-    mInputData->mAdsorbedMass = -FLT_EPSILON;
+    mInputData->mAdsorbedMass = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mAdsorbedMass = mAdsorbedMass;
 
     /// @test    Initialization exception on invalid input data: wall temperature < 0.
-    mInputData->mWallTemperature = -FLT_EPSILON;
+    mInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mWallTemperature = mWallTemperature;

--- a/aspects/fluid/source/test/UtGunnsFluidHotAdsorber.cpp
+++ b/aspects/fluid/source/test/UtGunnsFluidHotAdsorber.cpp
@@ -729,49 +729,49 @@ void UtGunnsFluidHotAdsorber::testInitializationExceptions()
     mConfigData->mGasType = FluidProperties::GUNNS_CO2;
 
     /// @test    Initialization exception on invalid config data: adsorption efficiency < 0.0.
-    mConfigData->mEfficiency = -FLT_EPSILON;
+    mConfigData->mEfficiency = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mEfficiency = mEfficiency;
 
     /// @test    Initialization exception on invalid config data: adsorption efficiency > 1.0.
-    mConfigData->mEfficiency = 1.0 + FLT_EPSILON;
+    mConfigData->mEfficiency = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mEfficiency = mEfficiency;
 
     /// @test    Initialization exception on invalid config data: maximum adsorbed mass < 0.0.
-    mConfigData->mMaxAdsorbtionRate = -FLT_EPSILON;
+    mConfigData->mMaxAdsorbtionRate = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mMaxAdsorbtionRate = mMaxAdsorbtionRate;
 
     /// @test    Initialization exception on invalid config data: maximum adsorption rate < 0.0.
-    mConfigData->mMaxAdsorbedMass = -FLT_EPSILON;
+    mConfigData->mMaxAdsorbedMass = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mMaxAdsorbedMass = mMaxAdsorbedMass;
 
-    /// @test    Initialization exception on invalid config data: desorbtion rate < 0.0.
-    mConfigData->mDesorbtionRate = -FLT_EPSILON;
+    /// @test    Initialization exception on invalid config data: desorption rate < 0.0.
+    mConfigData->mDesorbtionRate = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mConfigData->mDesorbtionRate = mDesorbtionRate;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mass in adsorber < 0.
-    mInputData->mAdsorbedMass = -FLT_EPSILON;
+    mInputData->mAdsorbedMass = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mAdsorbedMass = mAdsorbedMass;

--- a/aspects/fluid/source/test/UtGunnsFluidSeparatorGas.cpp
+++ b/aspects/fluid/source/test/UtGunnsFluidSeparatorGas.cpp
@@ -391,7 +391,7 @@ void UtGunnsFluidSeparatorGas::testUpdateFluidEmpty()
     const double expectedDeltaP   = 0.0;
     const double expectedSource   = 0.0;
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedHumidity, tArticle->mRelativeHumidity, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMass,     tArticle->mLiquidMass,       DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMassErr,  tArticle->mLiquidMassError,  DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDeltaP,   tArticle->mLiquidDeltaP,     DBL_EPSILON);
@@ -487,12 +487,12 @@ void UtGunnsFluidSeparatorGas::testUpdateFluidFull()
                                   * std::pow(expectedMass, tMassExponent);
     const double expectedSource   = expectedSepRate / 18.0153;     // MW of H2O
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedHumidity, tArticle->mRelativeHumidity, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMass,     tArticle->mLiquidMass,       DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDeltaP,   tArticle->mLiquidDeltaP,     DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(true == tArticle->mLiquidOverflow);
 
     UT_PASS;
@@ -555,12 +555,12 @@ void UtGunnsFluidSeparatorGas::testUpdateFluidNominal()
                                   * std::pow(expectedMass, tMassExponent);
     const double expectedSource   = expectedSepRate / 18.0153;     // MW of H2O
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedHumidity, tArticle->mRelativeHumidity, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMass,     tArticle->mLiquidMass,       DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDeltaP,   tArticle->mLiquidDeltaP,     DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(false == tArticle->mLiquidOverflow);
 
     UT_PASS;
@@ -584,8 +584,8 @@ void UtGunnsFluidSeparatorGas::testProcessOutputs()
     const double expectedXferP = tNodes[0].getPotential() + 0.01;
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(tNodes[0].getContent()->getTemperature(),
-                                 tArticle->mTransferTemperature, FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedXferP, tArticle->mTransferPressure, FLT_EPSILON);
+                                 tArticle->mTransferTemperature, static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedXferP, tArticle->mTransferPressure, static_cast<double>(FLT_EPSILON));
 
     UT_PASS;
 }
@@ -628,12 +628,12 @@ void UtGunnsFluidSeparatorGas::testUpdateFluidReverseFlow()
                                   * std::pow(expectedMass, tMassExponent);
     const double expectedSource   = expectedSepRate / 18.0153;     // MW of H2O
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedHumidity, tArticle->mRelativeHumidity, DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedSepRate,  tArticle->mSeparationRate,   static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMass,     tArticle->mLiquidMass,       DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedDeltaP,   tArticle->mLiquidDeltaP,     DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,              tArticle->mSourceVector[0],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSource,  tArticle->mSourceVector[1],  static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(-expectedSepRate, tNodes[1].getInflux(),       static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT(false == tArticle->mLiquidOverflow);
 
     UT_PASS;
@@ -659,12 +659,12 @@ void UtGunnsFluidSeparatorGas::testInitializationExceptions()
     tConfigData->mGasType = tGasType;
 
     /// @test    Initialization exception on invalid config data: mass exponent < 0.1.
-    tConfigData->mMassExponent = 0.1 - FLT_EPSILON;
+    tConfigData->mMassExponent = 0.1 - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
 
     /// @test    Initialization exception on invalid config data: mass exponent > 10.0.
-    tConfigData->mMassExponent = 10.0 + FLT_EPSILON;
+    tConfigData->mMassExponent = 10.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tConfigData->mMassExponent = tMassExponent;
@@ -695,25 +695,25 @@ void UtGunnsFluidSeparatorGas::testInitializationExceptions()
     tConfigData->mReferenceRemovalRate = tReferenceRemovalRate;
 
     /// @test    Initialization exception on invalid input data: mBlockage < 0.
-    tInputData->mMalfBlockageValue = -FLT_EPSILON;
+    tInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mMalfBlockageValue = tMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: mBlockage > 1.
-    tInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    tInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mMalfBlockageValue = tMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: separator speed < 0.
-    tInputData->mSeparatorSpeed = -FLT_EPSILON;
+    tInputData->mSeparatorSpeed = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mSeparatorSpeed = tSeparatorSpeed;
 
     /// @test    Initialization exception on invalid input data: mass of liquid in separator < 0.
-    tInputData->mLiquidMass = -FLT_EPSILON;
+    tInputData->mLiquidMass = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mLiquidMass = tLiquidMass;

--- a/aspects/fluid/source/test/UtGunnsFluidSeparatorLiquid.cpp
+++ b/aspects/fluid/source/test/UtGunnsFluidSeparatorLiquid.cpp
@@ -433,19 +433,19 @@ void UtGunnsFluidSeparatorLiquid::testInitializationExceptions()
     mConfigData->mLiquidType = FluidProperties::GUNNS_WATER;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value < 0.
-    mInputData->mMalfBlockageValue = -FLT_EPSILON;
+    mInputData->mMalfBlockageValue = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: blockage malfunction value > 1.
-    mInputData->mMalfBlockageValue = 1.0 + FLT_EPSILON;
+    mInputData->mMalfBlockageValue = 1.0 + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mMalfBlockageValue = mMalfBlockageValue;
 
     /// @test    Initialization exception on invalid input data: transfer temperature < 0.
-    mInputData->mTransferTemperature = -FLT_EPSILON;
+    mInputData->mTransferTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfigData, *mInputData, mLinks, mPort0, mPort1),
                          TsInitializationException);
     mInputData->mTransferTemperature = mTransferTemperature;

--- a/aspects/fluid/source/test/UtGunnsFluidSorptionBed.cpp
+++ b/aspects/fluid/source/test/UtGunnsFluidSorptionBed.cpp
@@ -524,7 +524,7 @@ void UtGunnsFluidSorptionBed::testInitializationExceptions()
     UT_RESULT;
 
     /// @test exception thrown on bed wall temperature out of range.
-    tInputData->mWallTemperature = -FLT_EPSILON;
+    tInputData->mWallTemperature = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mWallTemperature = tWallTemperature;
@@ -537,8 +537,8 @@ void UtGunnsFluidSorptionBed::testInitializationExceptions()
     tInputData->mLoading.at(0).mSegment = savedSegment;
 
     /// @test exception thrown on segment loading's loading value out of range.
-    const unsigned int savedLoading = tInputData->mLoading.at(0).mLoading;
-    tInputData->mLoading.at(0).mLoading = -FLT_EPSILON;
+    const unsigned int savedLoading = static_cast<unsigned int>(tInputData->mLoading.at(0).mLoading);
+    tInputData->mLoading.at(0).mLoading = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfigData, *tInputData, tLinks, tPort0, tPort1),
                          TsInitializationException);
     tInputData->mLoading.at(0).mLoading = savedLoading;
@@ -712,7 +712,7 @@ void UtGunnsFluidSorptionBed::testBedSorbateUpdateLoading()
         tArticle->mSegments[0].mSorbates[1].updateLoading(tTimeStep, influx, 999.9);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedRate,     tArticle->mSegments[0].mSorbates[1].mLoadingRate,     100.0 * DBL_EPSILON);
         CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedLoading,  tArticle->mSegments[0].mSorbates[1].mLoading,         100.0 * DBL_EPSILON);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFraction, tArticle->mSegments[0].mSorbates[1].mLoadingFraction, FLT_EPSILON);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedFraction, tArticle->mSegments[0].mSorbates[1].mLoadingFraction, static_cast<double>(FLT_EPSILON));
     } {
         /// @test nominal equilibrium loading < loading, desorb rate not limited.
         const double loading          = 1.25 * loadingEquil;

--- a/aspects/thermal/network/test/UtThermalNetwork.cpp
+++ b/aspects/thermal/network/test/UtThermalNetwork.cpp
@@ -265,7 +265,7 @@ void UtThermalNetwork::testInitialize()
     CPPUNIT_ASSERT_EQUAL(parserFriendly.numLinksSrc,  tArticle->numLinksSrc);
     CPPUNIT_ASSERT_EQUAL(parserFriendly.numLinksHtr,  tArticle->numLinksHtr);
     CPPUNIT_ASSERT_EQUAL(parserFriendly.numLinksPan,  tArticle->numLinksPan);
-    CPPUNIT_ASSERT(parserFriendly.vCapEditGroupList.size() == tArticle->numCapEditGroups);
+    CPPUNIT_ASSERT(parserFriendly.vCapEditGroupList.size() == static_cast<std::size_t>(tArticle->numCapEditGroups));
 
     /// @test  Initialization of capacitance edit group controls
     for(int i = 0; i < tArticle->numCapEditGroups; ++i)
@@ -450,7 +450,7 @@ void UtThermalNetwork::testConfigBuild()
 
         /// - The flux-distribution-fraction vector is a different size for each source, since sources
         ///   have a variable number of ports.
-        for(int ii = 0; ii < tArticle->mSourceConfigData[i]->cFluxDistributionFractions.size(); ++ii)
+        for(std::size_t ii = 0; ii < tArticle->mSourceConfigData[i]->cFluxDistributionFractions.size(); ++ii)
         {
             /// @test Sources: power-draw fractions
             CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "Source efficiency, index: " + out.str(),
@@ -474,7 +474,7 @@ void UtThermalNetwork::testConfigBuild()
 
         /// - The flux-distribution-fraction vector is a different size for each heater, since heaters
         ///   have a variable number of ports.
-        for(int ii = 0; ii < tArticle->mHeaterConfigData[i]->cFluxDistributionFractions.size(); ++ii)
+        for(std::size_t ii = 0; ii < tArticle->mHeaterConfigData[i]->cFluxDistributionFractions.size(); ++ii)
         {
             /// @test Heaters: power-draw fractions
             CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "Heater efficiency, index: " + out.str(),
@@ -504,7 +504,7 @@ void UtThermalNetwork::testConfigBuild()
 
         /// - The flux-distribution-fraction vector is a different size for each panel, since panels
         ///   have a variable number of ports.
-        for(int ii = 0; ii < tArticle->mPanelConfigData[i]->cFluxDistributionFractions.size(); ++ii)
+        for(std::size_t ii = 0; ii < tArticle->mPanelConfigData[i]->cFluxDistributionFractions.size(); ++ii)
         {
             /// @test Panels: power-draw fractions
             CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE( "Panel efficiency, index: " + out.str(),

--- a/core/test/UtGunns.cpp
+++ b/core/test/UtGunns.cpp
@@ -424,7 +424,7 @@ void UtGunns::testDefaultConstruction()
     CPPUNIT_ASSERT(-1            == tNetwork.mDebugDesiredNode);
     CPPUNIT_ASSERT(false         == tNetwork.mVerbose);
     CPPUNIT_ASSERT(false         == tNetwork.mSorActive);
-    CPPUNIT_ASSERT(1.0           == tNetwork.mSorWeight);
+    CPPUNIT_ASSERT(1.0F          == tNetwork.mSorWeight);
     CPPUNIT_ASSERT(100           == tNetwork.mSorMaxIter);
     CPPUNIT_ASSERT(1.0e-12       == tNetwork.mSorTolerance);
     CPPUNIT_ASSERT(-1            == tNetwork.mSorLastIteration);

--- a/core/test/UtGunnsBasicLink.cpp
+++ b/core/test/UtGunnsBasicLink.cpp
@@ -387,10 +387,10 @@ void UtGunnsBasicLink::testModifiers()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(minLinearP, mArticle->mMinLinearizationPotential, mTolerance);
 
     /// @test that the network name gets set
-    char* name = new char[strlen(mLinkName.c_str())+1];
-    strcpy(name, mLinkName.c_str());
+    char* name = new char[std::strlen(mLinkName.c_str())+1];
+    std::strcpy(name, mLinkName.c_str());
 
-    for (int i=0; i<strlen(mLinkName.c_str())+1; ++i) {
+    for (std::size_t i=0; i<std::strlen(mLinkName.c_str())+1; ++i) {
         CPPUNIT_ASSERT(name[i] == mArticle->mName[i]);
     }
     delete [] name;

--- a/core/test/UtGunnsDistributed2WayBusBase.cpp
+++ b/core/test/UtGunnsDistributed2WayBusBase.cpp
@@ -119,7 +119,7 @@ void UtGunnsDistributed2WayBusBase::testFrameCounts()
     tArticle->updateFrameCounts();
     CPPUNIT_ASSERT(expectedOutFrameCount == tOutData.mFrameCount);
     CPPUNIT_ASSERT(expectedFramesFlip    == tArticle->mFramesSinceFlip);
-    CPPUNIT_ASSERT(expectedLoopLatency   == tArticle->mLoopLatency);
+    CPPUNIT_ASSERT(expectedLoopLatency   == static_cast<unsigned int>(tArticle->mLoopLatency));
     CPPUNIT_ASSERT(tInData.mFrameCount   == tOutData.mFrameLoopback);
 
     std::cout << "... Pass";

--- a/core/test/UtGunnsFluidDistributed2WayBus.cpp
+++ b/core/test/UtGunnsFluidDistributed2WayBus.cpp
@@ -548,7 +548,7 @@ void UtGunnsFluidDistributed2WayBus::testDemandLimit()
     const double timestep           = 0.1;
     const double demandSideP        = 100000.0;  // ~1 atm, dP = 1%
     double csOverCd     = 1.25; // default moding capacitance ratio upper limit
-    double gainLimit    = 1.5 * std::pow(0.75, 4); // default demand filter constants A & B
+    double gainLimit    = 1.5 * std::pow(0.75, 4.0); // default demand filter constants A & B
     double expectedGain = gainLimit + (1.0 - gainLimit) * (csOverCd - 1.0) * 4.0;
     double expectedNdot = expectedGain * (demandSideP - tArticle->mInData.mSource) / timestep
                         / (1.0 / tArticle->mOutData.mCapacitance + 1.0 / tArticle->mInData.mCapacitance);

--- a/core/test/UtGunnsFluidDistributedIf.cpp
+++ b/core/test/UtGunnsFluidDistributedIf.cpp
@@ -753,7 +753,7 @@ void UtGunnsFluidDistributedIf::testStep()
     tArticle->mSourcePressure       = 100.0;
     const double timestep           = 0.1;
     double csOverCd     = 1.25; // default moding capacitance ratio upper limit
-    double gainLimit    = 1.5 * std::pow(0.75, 4); // default demand filter connstants A & B
+    double gainLimit    = 1.5 * std::pow(0.75, 4.0); // default demand filter connstants A & B
     double expectedGain = gainLimit + (1.0 - gainLimit) * (csOverCd - 1.0) * 4.0;
     double conductance  = expectedGain * 1.0 / timestep;
     double expectedG    = conductance; // mDemandOption is set in config data
@@ -789,7 +789,7 @@ void UtGunnsFluidDistributedIf::testStep()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedG,    tArticle->mEffectiveConductivity, DBL_EPSILON);
 
     tArticleInterface->mLoopLatency = 200;
-    gainLimit    = 1.5 * std::pow(0.75, 100);
+    gainLimit    = 1.5 * std::pow(0.75, 100.0);
     expectedGain = gainLimit + (1.0 - gainLimit) * (csOverCd - 1.0) * 4.0;
     conductance  = expectedGain * 0.9 / timestep;
     expectedG    = conductance;
@@ -802,7 +802,7 @@ void UtGunnsFluidDistributedIf::testStep()
     tArticleInterface->mInData.mCapacitance  = 1.15;
     tArticleInterface->mLoopLatency          = 2;
     csOverCd     = 1.15;
-    gainLimit    = 1.5 * std::pow(0.75, 2);
+    gainLimit    = 1.5 * std::pow(0.75, 2.0);
     expectedGain = gainLimit + (1.0 - gainLimit) * (csOverCd - 1.0) * 4.0;
     conductance  = expectedGain * 1.15 / timestep;
     expectedG    = conductance;
@@ -816,7 +816,7 @@ void UtGunnsFluidDistributedIf::testStep()
     tArticleInterface->mInData.mCapacitance  = 1.0;
     tArticleInterface->mLoopLatency          = 4;
     csOverCd     = 1.25;
-    gainLimit    = 1.5 * std::pow(0.75, 4);
+    gainLimit    = 1.5 * std::pow(0.75, 4.0);
     expectedGain = gainLimit + (1.0 - gainLimit) * (csOverCd - 1.0) * 4.0;
     conductance  = expectedGain * 1.0 / timestep;
     expectedG    = 1.0 / (1.0 / conductance + timestep / 0.5);

--- a/core/test/UtGunnsFluidNode.cpp
+++ b/core/test/UtGunnsFluidNode.cpp
@@ -294,8 +294,8 @@ void UtGunnsFluidNode::testLowTempThermalCapacitance()
 
     /// - Call PolyFluid directly for the same density perturbation that computeCapacitance does,
     ///   and verify it matches this hardcoded result.  This is a redundant check on PolyFluid.
-    double T1 = 0.999 * 0.5 * FLT_EPSILON;
-    double T2 = 1.001 * 0.5 * FLT_EPSILON;
+    double T1 = 0.999 * 0.5 * static_cast<double>(FLT_EPSILON);
+    double T2 = 1.001 * 0.5 * static_cast<double>(FLT_EPSILON);
     double rho1 = tFluid.computeDensity(T1, 100.0); // Should be 5.5885273962925748
     double rho2 = tFluid.computeDensity(T2, 100.0); // Should be 5.5885273962925748
 
@@ -308,7 +308,7 @@ void UtGunnsFluidNode::testLowTempThermalCapacitance()
             (tNode.getContent()->getTemperature() - tNode.mPreviousTemperature);
 
     /// - Call computeThermalCapacitance and verify correct mCapacitance and return value result.
-    tNode.getContent()->setTemperature(0.5 * FLT_EPSILON);
+    tNode.getContent()->setTemperature(0.5 * static_cast<double>(FLT_EPSILON));
     double tResult = tNode.computeThermalCapacitance();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(thermalSource, tResult,                   DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(capacitance,   tNode.mThermalCapacitance, DBL_EPSILON);
@@ -1536,15 +1536,15 @@ void UtGunnsFluidNode::testValidate()
                                                          idealDensity);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(idealDensity,  tNode2.getContent()->getDensity(),  DBL_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(idealPressure, tNode2.getContent()->getPressure(),
-            100.0 * FLT_EPSILON);
+            100.0 * static_cast<double>(FLT_EPSILON));
 
     idealTemperature =
             tNode2.getContent()->computeTemperature(tNode2.getContent()->getSpecificEnthalpy());
     idealSpecificEnthalpy = tNode2.getContent()->computeSpecificEnthalpy(idealTemperature);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(idealTemperature,
-            tNode2.getContent()->getTemperature(), FLT_EPSILON); // These fail DBL_ due to roundoff
+            tNode2.getContent()->getTemperature(), static_cast<double>(FLT_EPSILON)); // These fail DBL_ due to roundoff
     CPPUNIT_ASSERT_DOUBLES_EQUAL(idealSpecificEnthalpy,
-            tNode2.getContent()->getSpecificEnthalpy(), FLT_EPSILON);
+            tNode2.getContent()->getSpecificEnthalpy(), static_cast<double>(FLT_EPSILON));
 
     std::cout << "... Pass";
 }
@@ -1601,7 +1601,7 @@ void UtGunnsFluidNode::testRestart()
     /// - Change the node's mContent to give it some mass error, and verify this causes the mass
     ///   to be reset.
     const double tMass = tNode.getContent()->getMass();
-    tNode.getContent()->setMass(tMass + 1.01 * FLT_EPSILON);
+    tNode.getContent()->setMass(tMass + 1.01 * static_cast<double>(FLT_EPSILON));
 
     tNode.restart();
 

--- a/core/test/UtGunnsFluidUtils.cpp
+++ b/core/test/UtGunnsFluidUtils.cpp
@@ -335,12 +335,12 @@ void UtGunnsFluidUtils::testLowPressureCapacitance()
     double molWeight = tFluid.getMWeight();    // Should be 2.8836520501689176e+01
 
     CPPUNIT_ASSERT_DOUBLES_EQUAL(2.8836520501689176e+01, molWeight,            DBL_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(FLT_EPSILON,            tFluid.getPressure(), DBL_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(static_cast<double>(FLT_EPSILON), tFluid.getPressure(), DBL_EPSILON);
 
     /// - Call PolyFluid directly for the same density perturbation that computeCapacitance does,
     ///   and verify it matches this hardcoded result.  This is a redundant check on PolyFluid.
-    double P1 = 0.999 * 0.5 * FLT_EPSILON;
-    double P2 = 1.001 * 0.5 * FLT_EPSILON;
+    double P1 = 0.999 * 0.5 * static_cast<double>(FLT_EPSILON);
+    double P2 = 1.001 * 0.5 * static_cast<double>(FLT_EPSILON);
     double rho1 = tFluid.computeDensity(300.0, P1);         // Should be 6.8838677529188106e-10
     double rho2 = tFluid.computeDensity(300.0, P2);         // Should be 6.8976492699416704e-10
 
@@ -351,7 +351,7 @@ void UtGunnsFluidUtils::testLowPressureCapacitance()
     double capacitance = (rho2 - rho1) * volume / (molWeight * (P2 - P1));
 
     /// - Call computeCapacitance and verify correct mCapacitance and return value result.
-    tFluid.setPressure(0.5 * FLT_EPSILON);
+    tFluid.setPressure(0.5 * static_cast<double>(FLT_EPSILON));
     double tResult = GunnsFluidUtils::computeCapacitance(&tFluid, volume);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(capacitance, tResult,            DBL_EPSILON);
 

--- a/core/test/UtGunnsMinorStepLog.cpp
+++ b/core/test/UtGunnsMinorStepLog.cpp
@@ -290,8 +290,8 @@ void UtGunnsMinorStepLog::testInitialize()
     CPPUNIT_ASSERT(GunnsMinorStepLog::PAUSED == tArticle->mState);
     CPPUNIT_ASSERT(true                      == tArticle->mIsRecording);
     CPPUNIT_ASSERT(tLogSteps                 == tArticle->mBuffer.size());
-    CPPUNIT_ASSERT(tNetworkSize              == tArticle->mBuffer[0].mPotentialVector.size());
-    CPPUNIT_ASSERT(tNumLinks                 == tArticle->mBuffer[0].mLinksData.size());
+    CPPUNIT_ASSERT(tNetworkSize              == static_cast<int>(tArticle->mBuffer[0].mPotentialVector.size()));
+    CPPUNIT_ASSERT(tNumLinks                 == static_cast<int>(tArticle->mBuffer[0].mLinksData.size()));
     CPPUNIT_ASSERT(tLogSteps                 == tArticle->mSize);
     CPPUNIT_ASSERT(tLogSteps - 1             == tArticle->mHeadIndex);
     CPPUNIT_ASSERT(0                         == tArticle->mNumValidSteps);
@@ -464,7 +464,7 @@ void UtGunnsMinorStepLog::testRecord()
 
     /// @test record functions don't record when recording isn't enabled.
     int index = tLogSteps - 1;
-    CPPUNIT_ASSERT(index == tArticle->mHeadIndex);
+    CPPUNIT_ASSERT(index == static_cast<int>(tArticle->mHeadIndex));
     double potentials[2] = {200.0, 300.0};
     tArticle->recordPotential(potentials);
     CPPUNIT_ASSERT(0.0 == tArticle->mBuffer[index].mPotentialVector[0]);
@@ -499,7 +499,7 @@ void UtGunnsMinorStepLog::testRecord()
 
     /// @test record functions when recording is enabled.
     index = 0;
-    CPPUNIT_ASSERT(index == tArticle->mHeadIndex);
+    CPPUNIT_ASSERT(index == static_cast<int>(tArticle->mHeadIndex));
     tArticle->recordPotential(potentials);
     CPPUNIT_ASSERT(potentials[0] == tArticle->mBuffer[index].mPotentialVector[0]);
     CPPUNIT_ASSERT(potentials[1] == tArticle->mBuffer[index].mPotentialVector[1]);

--- a/core/test/UtGunnsSensorAnalogWrapper.cpp
+++ b/core/test/UtGunnsSensorAnalogWrapper.cpp
@@ -19,16 +19,16 @@ UtGunnsSensorAnalogWrapper::UtGunnsSensorAnalogWrapper()
     tName(""),
     tConfig(),
     tInput(),
-    tMinRange(0.0),
-    tMaxRange(0.0),
-    tOffValue(0.0),
-    tNominalBias(0.0),
-    tNominalScale(0.0),
-    tNominalNoiseScale(0.0),
-    tNominalResolution(0.0),
+    tMinRange(0.0F),
+    tMaxRange(0.0F),
+    tOffValue(0.0F),
+    tNominalBias(0.0F),
+    tNominalScale(0.0F),
+    tNominalNoiseScale(0.0F),
+    tNominalResolution(0.0F),
     tNoiseFunction(),
     tUnitConversion(),
-    tNominalNoiseMult(0.0),
+    tNominalNoiseMult(0.0F),
     tPowerFlag(false),
     tTruthInput(0.0),
     tTimeStep()
@@ -62,14 +62,14 @@ void UtGunnsSensorAnalogWrapper::setUp()
 {
     /// - Define nominal config data.
     tName              = "Test Sensor";
-    tMinRange          =  1.0;
-    tMaxRange          = 49.0;
-    tOffValue          =  5.0;
-    tNominalBias       =  0.1;
-    tNominalScale      =  0.99;
-    tNominalNoiseScale =  1.0;
-    tNominalNoiseMult  =  0.01;
-    tNominalResolution =  0.2;
+    tMinRange          =  1.0F;
+    tMaxRange          = 49.0F;
+    tOffValue          =  5.0F;
+    tNominalBias       =  0.1F;
+    tNominalScale      =  0.99F;
+    tNominalNoiseScale =  1.0F;
+    tNominalNoiseMult  =  0.01F;
+    tNominalResolution =  0.2F;
     tNoiseFunction     = UtSensorAnalogNoise::testNoise;
     tUnitConversion    = UnitConversion::NO_CONVERSION;
     tConfig = new GunnsSensorAnalogWrapperConfigData(tName,
@@ -117,13 +117,13 @@ void UtGunnsSensorAnalogWrapper::testConfig()
     /// - Test default config data construction.
     GunnsSensorAnalogWrapperConfigData defaultConfig(tName);
     CPPUNIT_ASSERT(tName                         == tConfig->mName);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mMinRange);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mMaxRange);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mOffValue);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mNominalBias);
-    CPPUNIT_ASSERT(1.0                           == defaultConfig.mSensor.mNominalScale);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mNominalNoiseScale);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mSensor.mNominalResolution);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mMinRange);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mMaxRange);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mOffValue);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mNominalBias);
+    CPPUNIT_ASSERT(1.0F                          == defaultConfig.mSensor.mNominalScale);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mNominalNoiseScale);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mSensor.mNominalResolution);
     CPPUNIT_ASSERT(TsNoise::getNoise             == defaultConfig.mSensor.mNoiseFunction);
     CPPUNIT_ASSERT(UnitConversion::NO_CONVERSION == defaultConfig.mSensor.mUnitConversion);
 
@@ -158,7 +158,7 @@ void UtGunnsSensorAnalogWrapper::testDefaultConstruction()
 
     /// @test state data
     CPPUNIT_ASSERT(""    == tArticle->mName);
-    CPPUNIT_ASSERT(0.0   == tArticle->mSensor.mDrift);
+    CPPUNIT_ASSERT(0.0F  == tArticle->mSensor.mDrift);
     CPPUNIT_ASSERT(false == tArticle->mStepPreSolverFlag);
     CPPUNIT_ASSERT(false == tArticle->mStepPostSolverFlag);
 
@@ -226,7 +226,7 @@ void UtGunnsSensorAnalogWrapper::testInitializeExceptions()
     delete badInput;
 
     /// - Test exception thrown from bad sensor init.
-    tConfig->mSensor.mMinRange = tMaxRange + 1.0;
+    tConfig->mSensor.mMinRange = tMaxRange + 1.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(tConfig, tInput), TsInitializationException);
     CPPUNIT_ASSERT(false == tArticle->mInitFlag);
     tConfig->mSensor.mMinRange = tMinRange;

--- a/core/test/UtGunnsSensorAnalogWrapper.hh
+++ b/core/test/UtGunnsSensorAnalogWrapper.hh
@@ -108,16 +108,16 @@ class UtGunnsSensorAnalogWrapper : public CppUnit::TestFixture
         std::string                         tName;              /**< (--) Instance name. */
         GunnsSensorAnalogWrapperConfigData* tConfig;            /**< (--) Nominal config data. */
         GunnsSensorAnalogWrapperInputData*  tInput;             /**< (--) Nominal input data. */
-        double                              tMinRange;          /**< (--) Nominal config data. */
-        double                              tMaxRange;          /**< (--) Nominal config data. */
-        double                              tOffValue;          /**< (--) Nominal config data. */
-        double                              tNominalBias;       /**< (--) Nominal config data. */
-        double                              tNominalScale;      /**< (--) Nominal config data. */
-        double                              tNominalNoiseScale; /**< (--) Nominal config data. */
-        double                              tNominalResolution; /**< (--) Nominal config data. */
+        float                               tMinRange;          /**< (--) Nominal config data. */
+        float                               tMaxRange;          /**< (--) Nominal config data. */
+        float                               tOffValue;          /**< (--) Nominal config data. */
+        float                               tNominalBias;       /**< (--) Nominal config data. */
+        float                               tNominalScale;      /**< (--) Nominal config data. */
+        float                               tNominalNoiseScale; /**< (--) Nominal config data. */
+        float                               tNominalResolution; /**< (--) Nominal config data. */
         double                            (*tNoiseFunction)();  /**< (--) Nominal config data */
         UnitConversion::Type                tUnitConversion;    /**< (--) Nominal config data */
-        double                              tNominalNoiseMult;  /**< (--) Nominal config data. */
+        float                               tNominalNoiseMult;  /**< (--) Nominal config data. */
         bool                                tPowerFlag;         /**< (--) Nominal input data. */
         double                              tTruthInput;        /**< (--) Nominal input data. */
         double                              tTimeStep;          /**< (--) Time step size for this test */

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsOpenCloseValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsOpenCloseValveController.cpp
@@ -130,7 +130,7 @@ void UtTsOpenCloseValveController::setUp()
     mEnabledFlag            = true;
     mCmd                    = 0.0;
     mCommand                = TsOpenCloseValveCmd(mEnabledFlag, mCmd > 0.0, mCmd < 0.0);
-    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - FLT_EPSILON, mCmdPosition < mMinCmdPosition + FLT_EPSILON);
+    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - static_cast<double>(FLT_EPSILON), mCmdPosition < mMinCmdPosition + static_cast<double>(FLT_EPSILON));
     mInput                  = new TsPoweredValveControllerInputData(mCmdPosition,
                                                                     mManualPositionFlag,
                                                                     mManualPositionValue,
@@ -722,33 +722,33 @@ void UtTsOpenCloseValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
-    mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionFlag  = true;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
-    mInput->mManualPositionFlag  = false;;
+    mInput->mManualPositionFlag  = false;
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on on transit time < 0.
-    mConfig->mTransitTime = -FLT_EPSILON;
+    mConfig->mTransitTime = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mTransitTime = mTransitTime;
@@ -760,7 +760,7 @@ void UtTsOpenCloseValveController::testInitializationExceptions()
     mConfig->mRefCmd = mRefCmd;
 
     /// @test  Exception on on hold power < 0.
-    mConfig->mHoldPower = -FLT_EPSILON;
+    mConfig->mHoldPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mHoldPower = mHoldPower;

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsPositionValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsPositionValveController.cpp
@@ -757,33 +757,33 @@ void UtTsPositionValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
     mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionFlag  = false;;
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on on transit time < 0.
-    mConfig->mTransitTime = -FLT_EPSILON;
+    mConfig->mTransitTime = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mTransitTime = mTransitTime;
@@ -795,7 +795,7 @@ void UtTsPositionValveController::testInitializationExceptions()
     mConfig->mRefCmd = mRefCmd;
 
     /// @test  Exception on on hold power < 0.
-    mConfig->mHoldPower = -FLT_EPSILON;
+    mConfig->mHoldPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mHoldPower = mHoldPower;

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsPoweredValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsPoweredValveController.cpp
@@ -763,33 +763,33 @@ void UtTsPoweredValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
-    mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionFlag  = true;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
-    mInput->mManualPositionFlag  = false;;
+    mInput->mManualPositionFlag  = false;
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on on transit time < 0.
-    mConfig->mTransitTime = -FLT_EPSILON;
+    mConfig->mTransitTime = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mTransitTime = mTransitTime;
@@ -801,19 +801,19 @@ void UtTsPoweredValveController::testInitializationExceptions()
     mConfig->mRefCmd = mRefCmd;
 
     /// @test  Exception on on hold power < 0.
-    mConfig->mHoldPower = -FLT_EPSILON;
+    mConfig->mHoldPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mHoldPower = mHoldPower;
 
     /// @test  Exception on on stuck power < 0.
-    mConfig->mStuckPower = -FLT_EPSILON;
+    mConfig->mStuckPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mStuckPower = mHoldPower;
 
     /// @test  Exception on on move power < 0.
-    mConfig->mMovePower = -FLT_EPSILON;
+    mConfig->mMovePower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mMovePower = mHoldPower;
@@ -892,4 +892,3 @@ void UtTsPoweredValveController::testUpdateAtHardStops()
 
     UT_PASS_LAST;
 }
-

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsSpeedValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsSpeedValveController.cpp
@@ -130,7 +130,7 @@ void UtTsSpeedValveController::setUp()
     mEnabledFlag            = true;
     mCmd                    = 10.0;
     mCommand                = TsSpeedValveCmd(mEnabledFlag, mCmd);
-    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - FLT_EPSILON, mCmdPosition < mMinCmdPosition + FLT_EPSILON);
+    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - static_cast<double>(FLT_EPSILON), mCmdPosition < mMinCmdPosition + static_cast<double>(FLT_EPSILON));
     mInput                  = new TsPoweredValveControllerInputData(mCmdPosition,
                                                                     mManualPositionFlag,
                                                                     mManualPositionValue,
@@ -731,33 +731,33 @@ void UtTsSpeedValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
     mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionFlag  = false;;
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on on transit time < 0.
-    mConfig->mTransitTime = -FLT_EPSILON;
+    mConfig->mTransitTime = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mTransitTime = mTransitTime;
@@ -769,7 +769,7 @@ void UtTsSpeedValveController::testInitializationExceptions()
     mConfig->mRefCmd = mRefCmd;
 
     /// @test  Exception on on hold power < 0.
-    mConfig->mHoldPower = -FLT_EPSILON;
+    mConfig->mHoldPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mHoldPower = mHoldPower;

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsTValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsTValveController.cpp
@@ -301,14 +301,14 @@ void UtTsTValveController::testInitializationExceptions()
     CPPUNIT_ASSERT(!mArticle->mInitialized);
 
     /// @test  Exception on path A config data valve maximum position < valve minimum position.
-    mConfig->mAPath.mMaxCmdPosition = mConfig->mAPath.mMinCmdPosition - FLT_EPSILON;
+    mConfig->mAPath.mMaxCmdPosition = mConfig->mAPath.mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(mArticle->initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!mArticle->isInitialized());
     mConfig->mAPath.mMaxCmdPosition = 1.0;
 
     /// @test  Exception on path B input data manual position  > max position.
     mInput->mBPath.mManualPositionFlag  = true;
-    mInput->mBPath.mManualPositionValue = mConfig->mBPath.mMaxCmdPosition + FLT_EPSILON;
+    mInput->mBPath.mManualPositionValue = mConfig->mBPath.mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(mArticle->initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!mArticle->isInitialized());
     mInput->mBPath.mManualPositionFlag  = false;

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsToggleValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsToggleValveController.cpp
@@ -130,7 +130,7 @@ void UtTsToggleValveController::setUp()
     mEnabledFlag            = true;
     mCmd                    = 0.0;
 //    mCommand                = TsToggleValveCmd(mEnabledFlag, true);
-    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - FLT_EPSILON, mCmdPosition < mMinCmdPosition + FLT_EPSILON);
+    mSensed                 = TsOpenCloseValveSensed(mCmdPosition > mMaxCmdPosition - static_cast<double>(FLT_EPSILON), mCmdPosition < mMinCmdPosition + static_cast<double>(FLT_EPSILON));
     mInput                  = new TsPoweredValveControllerInputData(mCmdPosition,
                                                                     mManualPositionFlag,
                                                                     mManualPositionValue,
@@ -717,33 +717,33 @@ void UtTsToggleValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
     mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionFlag  = false;;
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on on transit time < 0.
-    mConfig->mTransitTime = -FLT_EPSILON;
+    mConfig->mTransitTime = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mTransitTime = mTransitTime;
@@ -755,7 +755,7 @@ void UtTsToggleValveController::testInitializationExceptions()
     mConfig->mRefCmd = mRefCmd;
 
     /// @test  Exception on on hold power < 0.
-    mConfig->mHoldPower = -FLT_EPSILON;
+    mConfig->mHoldPower = -static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mConfig->mHoldPower = mHoldPower;

--- a/gunns-ts-models/common/controllers/fluid/test/UtTsValveController.cpp
+++ b/gunns-ts-models/common/controllers/fluid/test/UtTsValveController.cpp
@@ -479,26 +479,26 @@ void UtTsValveController::testInitializationExceptions()
     mConfig->mMaxFluidPosition = mMaxFluidPosition;
 
     /// @test  Exception on valve position < min position.
-    mInput->mCmdPosition = mMinCmdPosition - FLT_EPSILON;
+    mInput->mCmdPosition = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on valve position > max position.
-    mInput->mCmdPosition = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mCmdPosition = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mCmdPosition = mCmdPosition;
 
     /// @test  Exception on on manual position < min position.
     mInput->mManualPositionFlag  = true;;
-    mInput->mManualPositionValue = mMinCmdPosition - FLT_EPSILON;
+    mInput->mManualPositionValue = mMinCmdPosition - static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionValue = mManualPositionValue;
 
     /// @test  Exception on manual position  > max position.
-    mInput->mManualPositionValue = mMaxCmdPosition + FLT_EPSILON;
+    mInput->mManualPositionValue = mMaxCmdPosition + static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(article.initialize(*mConfig, *mInput, mName), TsInitializationException);
     CPPUNIT_ASSERT(!article.isInitialized());
     mInput->mManualPositionFlag  = false;;

--- a/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsDualSolenoidValveAssembly.cpp
+++ b/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsDualSolenoidValveAssembly.cpp
@@ -54,11 +54,11 @@ void UtTsDualSolenoidValveAssembly::setUp()
     cController.mMaxFluidPosition    = 1.0;
     cController.mLatch               = TsDualSolenoidValveController::LATCHING;
     cSensorOpen.mOffValue            = false;
-    cSensorOpen.mTarget              = 1.0;
-    cSensorOpen.mTolerance           = 0.1;
+    cSensorOpen.mTarget              = 1.0F;
+    cSensorOpen.mTolerance           = 0.1F;
     cSensorClosed.mOffValue          = false;
-    cSensorClosed.mTarget            = 0.0;
-    cSensorClosed.mTolerance         = 0.1;
+    cSensorClosed.mTarget            = 0.0F;
+    cSensorClosed.mTolerance         = 0.1F;
     tConfig                          = new TsDualSolenoidValveAssemblyConfigData(cController,
                                                                                  cSensorOpen,
                                                                                  cSensorClosed);
@@ -71,7 +71,7 @@ void UtTsDualSolenoidValveAssembly::setUp()
     iController.mCloseSolenoidCmd    = false;
     iSensorOpen.mPowerFlag           = true;
     iSensorOpen.mTruthInput          = false;
-    iSensorOpen.mTruthInputAnalog    = 0.0;
+    iSensorOpen.mTruthInputAnalog    = 0.0F;
     iSensorClosed.mPowerFlag         = true;
     iSensorClosed.mTruthInput        = false;
     iSensorClosed.mTruthInputAnalog  = 0.0;
@@ -312,13 +312,13 @@ void UtTsDualSolenoidValveAssembly::testInitializationFailure()
 
     /// @test    Assembly fails to init if open sensor fails to init.
     tConfig->mController.mMinCmdPosition =  0.0;
-    tConfig->mSensorOpen.mTolerance      = -1.0;
+    tConfig->mSensorOpen.mTolerance      = -1.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfig, *tInput, tName), TsInitializationException);
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);
 
     /// @test    Assembly fails to init if closed sensor fails to init.
-    tConfig->mSensorClosed.mTolerance    =  0.1;
-    tConfig->mSensorClosed.mTolerance    = -1.0;
+    tConfig->mSensorClosed.mTolerance    =  0.1F;
+    tConfig->mSensorClosed.mTolerance    = -1.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfig, *tInput, tName), TsInitializationException);
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);
 

--- a/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsOpenCloseValveAssembly.cpp
+++ b/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsOpenCloseValveAssembly.cpp
@@ -62,10 +62,10 @@ void UtTsOpenCloseValveAssembly::setUp()
     cController.mLatch               = TsPoweredValveController::LATCHING;
     cSensorOpen.mOffValue            = false;
     cSensorOpen.mTarget              = 1.0;
-    cSensorOpen.mTolerance           = 0.1;
+    cSensorOpen.mTolerance           = 0.1F;
     cSensorClosed.mOffValue          = false;
     cSensorClosed.mTarget            = 0.0;
-    cSensorClosed.mTolerance         = 0.1;
+    cSensorClosed.mTolerance         = 0.1F;
     tConfig                          = new TsOpenCloseValveAssemblyConfigData(cController,
                                                                               cSensorOpen,
                                                                               cSensorClosed);
@@ -367,7 +367,7 @@ void UtTsOpenCloseValveAssembly::testInitializationFailure()
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);
 
     /// @test    Assembly fails to init if closed sensor fails to init.
-    tConfig->mSensorClosed.mTolerance    =  0.1;
+    tConfig->mSensorClosed.mTolerance    =  0.1F;
     tConfig->mSensorClosed.mTolerance    = -1.0;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfig, *tInput, tName), TsInitializationException);
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);

--- a/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsToggleValveAssembly.cpp
+++ b/gunns-ts-models/common/controllers/valveAssemblies/test/UtTsToggleValveAssembly.cpp
@@ -61,11 +61,11 @@ void UtTsToggleValveAssembly::setUp()
     cController.mEotInterrupt        = true;
     cController.mLatch               = TsToggleValveController::LATCHING;
     cSensorOpen.mOffValue            = false;
-    cSensorOpen.mTarget              = 1.0;
-    cSensorOpen.mTolerance           = 0.1;
+    cSensorOpen.mTarget              = 1.0F;
+    cSensorOpen.mTolerance           = 0.1F;
     cSensorClosed.mOffValue          = false;
-    cSensorClosed.mTarget            = 0.0;
-    cSensorClosed.mTolerance         = 0.1;
+    cSensorClosed.mTarget            = 0.0F;
+    cSensorClosed.mTolerance         = 0.1F;
     tConfig                          = new TsToggleValveAssemblyConfigData(cController,
                                                                            cSensorOpen,
                                                                            cSensorClosed);
@@ -79,10 +79,10 @@ void UtTsToggleValveAssembly::setUp()
     iController.mCmd                 = 1.0;
     iSensorOpen.mPowerFlag           = true;
     iSensorOpen.mTruthInput          = false;
-    iSensorOpen.mTruthInputAnalog    = 0.0;
+    iSensorOpen.mTruthInputAnalog    = 0.0F;
     iSensorClosed.mPowerFlag         = true;
     iSensorClosed.mTruthInput        = false;
-    iSensorClosed.mTruthInputAnalog  = 0.0;
+    iSensorClosed.mTruthInputAnalog  = 0.0F;
     tInput                           = new TsToggleValveAssemblyInputData(iController,
                                                                           iSensorOpen,
                                                                           iSensorClosed);
@@ -362,13 +362,13 @@ void UtTsToggleValveAssembly::testInitializationFailure()
 
     /// @test    Assembly fails to init if open sensor fails to init.
     tConfig->mController.mMinCmdPosition =  0.0;
-    tConfig->mSensorOpen.mTolerance      = -1.0;
+    tConfig->mSensorOpen.mTolerance      = -1.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfig, *tInput, tName), TsInitializationException);
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);
 
     /// @test    Assembly fails to init if closed sensor fails to init.
-    tConfig->mSensorClosed.mTolerance    =  0.1;
-    tConfig->mSensorClosed.mTolerance    = -1.0;
+    tConfig->mSensorClosed.mTolerance    =  0.1F;
+    tConfig->mSensorClosed.mTolerance    = -1.0F;
     CPPUNIT_ASSERT_THROW(tArticle->initialize(*tConfig, *tInput, tName), TsInitializationException);
     CPPUNIT_ASSERT(                                          !tArticle->mInitialized);
 

--- a/gunns-ts-models/common/sensors/SensorVlvOpenClose.hh
+++ b/gunns-ts-models/common/sensors/SensorVlvOpenClose.hh
@@ -41,8 +41,8 @@ public:
     SensorBooleanAiConfigData mClose;   /**< (--) trick_chkpnt_io(**) CLose sensor config */
 
     SensorVlvOpenCloseConfigData(
-            const SensorBooleanAiConfigData &open  = SensorBooleanAiConfigData(false, 1.0,  0.0001),
-            const SensorBooleanAiConfigData &close = SensorBooleanAiConfigData(false, 0.0,  0.0001));
+            const SensorBooleanAiConfigData &open  = SensorBooleanAiConfigData(false, 1.0F,  0.0001F),
+            const SensorBooleanAiConfigData &close = SensorBooleanAiConfigData(false, 0.0F,  0.0001F));
     virtual ~SensorVlvOpenCloseConfigData();
 
     // ok to use compiler generated copy constructor and operator=

--- a/gunns-ts-models/common/sensors/test/UtSensorAnalog.cpp
+++ b/gunns-ts-models/common/sensors/test/UtSensorAnalog.cpp
@@ -56,14 +56,14 @@ void UtSensorAnalog::setUp()
 {
     /// - Define nominal config data.
     tName                 = "Test Sensor";
-    tMinRange             =  1.0;
-    tMaxRange             = 49.0;
-    tOffValue             =  5.0;
-    tNominalBias          =  0.1;
-    tNominalScale         =  0.99;
-    tNominalNoiseScale    =  1.0;
-    tNominalNoiseMult     =  0.01;
-    tNominalResolution    =  0.2;
+    tMinRange             =  1.0F;
+    tMaxRange             = 49.0F;
+    tOffValue             =  5.0F;
+    tNominalBias          =  0.1F;
+    tNominalScale         =  0.99F;
+    tNominalNoiseScale    =  1.0F;
+    tNominalNoiseMult     =  0.01F;
+    tNominalResolution    =  0.2F;
     tNominalNoiseFunction = UtSensorAnalogNoise::testNoise;
     tUnitConversion       = UnitConversion::NO_CONVERSION;
     tNominalConfig = new SensorAnalogConfigData(tMinRange,
@@ -105,13 +105,13 @@ void UtSensorAnalog::testConfigData()
 
     /// - Test default construction of a test config data article.
     SensorAnalogConfigData defaultConfig;
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mMinRange);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mMaxRange);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mOffValue);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mNominalBias);
-    CPPUNIT_ASSERT(1.0                           == defaultConfig.mNominalScale);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mNominalNoiseScale);
-    CPPUNIT_ASSERT(0.0                           == defaultConfig.mNominalResolution);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mMinRange);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mMaxRange);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mOffValue);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mNominalBias);
+    CPPUNIT_ASSERT(1.0F                          == defaultConfig.mNominalScale);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mNominalNoiseScale);
+    CPPUNIT_ASSERT(0.0F                          == defaultConfig.mNominalResolution);
     CPPUNIT_ASSERT(0                             == defaultConfig.mNoiseFunction);
     CPPUNIT_ASSERT(UnitConversion::NO_CONVERSION == defaultConfig.mUnitConversion);
 
@@ -182,18 +182,18 @@ void UtSensorAnalog::testInputData()
     CPPUNIT_ASSERT(false == defaultInput.mMalfIgnorePower);
     CPPUNIT_ASSERT(false == defaultInput.mMalfPerfectSensor);
     CPPUNIT_ASSERT(0.0   == defaultInput.mTruthInput);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfFailToValue);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfFailToValue);
     CPPUNIT_ASSERT(false == defaultInput.mMalfScaleFlag);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfScaleValue);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfScaleValue);
     CPPUNIT_ASSERT(false == defaultInput.mMalfBiasFlag);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfBiasValue);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfBiasValue);
     CPPUNIT_ASSERT(false == defaultInput.mMalfDriftFlag);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfDriftRate);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfDriftRate);
     CPPUNIT_ASSERT(false == defaultInput.mMalfNoiseFlag);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfNoiseScale);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfNoiseScale);
     CPPUNIT_ASSERT(false == defaultInput.mMalfResolutionFlag);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mMalfResolutionValue);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mDrift);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mMalfResolutionValue);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mDrift);
 
     /// - Test nominal construction of a test input data article.
     SensorAnalogInputData nominalInput(true, 10.0);
@@ -304,28 +304,28 @@ void UtSensorAnalog::testConstruction()
     CPPUNIT_ASSERT(false                         == article.mInitFlag);
 
     /// - Test default construction of the test article.
-    CPPUNIT_ASSERT(0.0                           == article.mMinRange);
-    CPPUNIT_ASSERT(0.0                           == article.mMaxRange);
-    CPPUNIT_ASSERT(0.0                           == article.mOffValue);
-    CPPUNIT_ASSERT(0.0                           == article.mNominalBias);
-    CPPUNIT_ASSERT(0.0                           == article.mNominalScale);
-    CPPUNIT_ASSERT(0.0                           == article.mNominalNoiseScale);
-    CPPUNIT_ASSERT(0.0                           == article.mNominalResolution);
+    CPPUNIT_ASSERT(0.0F                          == article.mMinRange);
+    CPPUNIT_ASSERT(0.0F                          == article.mMaxRange);
+    CPPUNIT_ASSERT(0.0F                          == article.mOffValue);
+    CPPUNIT_ASSERT(0.0F                          == article.mNominalBias);
+    CPPUNIT_ASSERT(0.0F                          == article.mNominalScale);
+    CPPUNIT_ASSERT(0.0F                          == article.mNominalNoiseScale);
+    CPPUNIT_ASSERT(0.0F                          == article.mNominalResolution);
     CPPUNIT_ASSERT(0.0                           == article.mTruthInput);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfFailToValue);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfFailToValue);
     CPPUNIT_ASSERT(false                         == article.mMalfScaleFlag);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfScaleValue);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfScaleValue);
     CPPUNIT_ASSERT(false                         == article.mMalfBiasFlag);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfBiasValue);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfBiasValue);
     CPPUNIT_ASSERT(false                         == article.mMalfDriftFlag);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfDriftRate);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfDriftRate);
     CPPUNIT_ASSERT(false                         == article.mMalfNoiseFlag);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfNoiseScale);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfNoiseScale);
     CPPUNIT_ASSERT(false                         == article.mMalfResolutionFlag);
-    CPPUNIT_ASSERT(0.0                           == article.mMalfResolutionValue);
-    CPPUNIT_ASSERT(0.0                           == article.mDrift);
+    CPPUNIT_ASSERT(0.0F                          == article.mMalfResolutionValue);
+    CPPUNIT_ASSERT(0.0F                          == article.mDrift);
     CPPUNIT_ASSERT(0.0                           == article.mTruthOutput);
-    CPPUNIT_ASSERT(0.0                           == article.mSensedOutput);
+    CPPUNIT_ASSERT(0.0F                          == article.mSensedOutput);
     CPPUNIT_ASSERT(0                             == article.mNoiseFunction);
     CPPUNIT_ASSERT(UnitConversion::NO_CONVERSION == article.mUnitConversion);
 
@@ -364,23 +364,23 @@ void UtSensorAnalog::testInitialize()
     CPPUNIT_ASSERT(tNominalResolution    == article.mNominalResolution);
     CPPUNIT_ASSERT(tTruthInput           == article.mTruthInput);
     CPPUNIT_ASSERT(tTruthInput           == article.mTruthOutput);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfFailToValue);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfFailToValue);
     CPPUNIT_ASSERT(false                 == article.mMalfScaleFlag);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfScaleValue);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfScaleValue);
     CPPUNIT_ASSERT(false                 == article.mMalfBiasFlag);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfBiasValue);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfBiasValue);
     CPPUNIT_ASSERT(false                 == article.mMalfDriftFlag);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfDriftRate);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfDriftRate);
     CPPUNIT_ASSERT(false                 == article.mMalfNoiseFlag);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfNoiseScale);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfNoiseScale);
     CPPUNIT_ASSERT(false                 == article.mMalfResolutionFlag);
-    CPPUNIT_ASSERT(0.0                   == article.mMalfResolutionValue);
-    CPPUNIT_ASSERT(0.0                   == article.mDrift);
+    CPPUNIT_ASSERT(0.0F                  == article.mMalfResolutionValue);
+    CPPUNIT_ASSERT(0.0F                  == article.mDrift);
     CPPUNIT_ASSERT(true                  == article.mInitFlag);
 
     /// - Based on the config & input data, verify the initial sensor output.
-    float expected =  tTruthInput * tNominalScale + tNominalBias + tNominalNoiseScale;
-    expected = tNominalResolution * static_cast<double>(round(expected/tNominalResolution));
+    float expected =  static_cast<float>(tTruthInput) * tNominalScale + tNominalBias + tNominalNoiseScale;
+    expected = tNominalResolution * std::round(expected/tNominalResolution);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
 
     std::cout << "... Pass";
@@ -448,17 +448,17 @@ void UtSensorAnalog::testInput()
 
     /// - Give the sensor an extremely small truth input and verify it is zeroed before applying the
     ///   units conversion.  This should result in absolute zero expressed in deg. F.
-    article.setTruthInput(FLT_MIN * 0.1);
-    double expected = -UnitConversion::ZERO_F_IN_R;
+    article.setTruthInput(static_cast<double>(FLT_MIN) * 0.1);
+    float expected = static_cast<float>(-UnitConversion::ZERO_F_IN_R);
     article.processInput();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, -FLT_EPSILON * expected);
 
     /// - Give the sensor a normal truth input and verify units conversion is correctly applied.
     ///   This should result in 32 deg. F.
     article.setTruthInput(273.15);
-    expected = UnitConversion::convertDegKToDegF(273.15);
+    expected = static_cast<float>(UnitConversion::convertDegKToDegF(273.15));
     article.processInput();
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON * 273.15);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON * 273.15F);
 
     std::cout << "... Pass";
 }
@@ -480,21 +480,21 @@ void UtSensorAnalog::testScale()
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify the scale output with no malfunction.
-    article.mSensedOutput = 10.0;
-    const float expected  = 10.0 * tNominalScale;
+    article.mSensedOutput = 10.0F;
+    const float expected  = 10.0F * tNominalScale;
     article.applyScale();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the scale output with malfunction added.
-    article.mSensedOutput    = 10.0;
+    article.mSensedOutput    = 10.0F;
     article.mMalfScaleFlag   = true;
-    article.mMalfScaleValue  = 0.5;
-    const float expectedMalf = expected * 0.5;
+    article.mMalfScaleValue  = 0.5F;
+    const float expectedMalf = expected * 0.5F;
     article.applyScale();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMalf, article.mSensedOutput, FLT_EPSILON);
 
     /// - Remove the malfunction and verify original result.
-    article.mSensedOutput   = 10.0;
+    article.mSensedOutput   = 10.0F;
     article.mMalfScaleFlag  = false;
     article.applyScale();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON);
@@ -519,21 +519,21 @@ void UtSensorAnalog::testBias()
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify the bias output with no malfunction.
-    article.mSensedOutput = 10.0;
-    const float expected  = 10.0 + tNominalBias;
+    article.mSensedOutput = 10.0F;
+    const float expected  = 10.0F + tNominalBias;
     article.applyBias();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the scale output with malfunction added.
-    article.mSensedOutput  = 10.0;
+    article.mSensedOutput  = 10.0F;
     article.mMalfBiasFlag  = true;
-    article.mMalfBiasValue = 0.5;
-    const float expectedMalf = expected + 0.5;
+    article.mMalfBiasValue = 0.5F;
+    const float expectedMalf = expected + 0.5F;
     article.applyBias();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expectedMalf, article.mSensedOutput, FLT_EPSILON);
 
     /// - Remove the malfunction and verify original result.
-    article.mSensedOutput = 10.0;
+    article.mSensedOutput = 10.0F;
     article.mMalfBiasFlag  = false;
     article.applyBias();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,     article.mSensedOutput, FLT_EPSILON);
@@ -558,33 +558,33 @@ void UtSensorAnalog::testDrift()
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify the drift output with no malfunction.
-    article.mSensedOutput  = 10.0;
-    const float expected   = 10.0;
+    article.mSensedOutput  = 10.0F;
+    const float expected   = 10.0F;
     article.applyDrift(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,  article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the drift output with malfunction active.
-    article.mSensedOutput  = 10.0;
+    article.mSensedOutput  = 10.0F;
     article.mMalfDriftFlag = true;
-    article.mMalfDriftRate = 1.0;
-    const float expected1  = expected + tTimeStep;
+    article.mMalfDriftRate = 1.0F;
+    const float expected1  = expected + static_cast<float>(tTimeStep);
     article.applyDrift(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected1, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify a 2nd drift frame with a different drift rate.
-    article.mSensedOutput  = 10.0;
+    article.mSensedOutput  = 10.0F;
     article.mMalfDriftFlag = true;
-    article.mMalfDriftRate = 1.5;
-    const float expected2  = expected1 + 1.5 * tTimeStep;
+    article.mMalfDriftRate = 1.5F;
+    const float expected2  = expected1 + 1.5F * static_cast<float>(tTimeStep);
     article.applyDrift(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected2, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify drift is zeroed when the malfunction is removed.
-    article.mSensedOutput  = 10.0;
+    article.mSensedOutput  = 10.0F;
     article.mMalfDriftFlag = false;
     article.applyDrift(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected,  article.mSensedOutput, FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,       article.mDrift,        0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0F,       article.mDrift,        0.0F);
 
     std::cout << "... Pass";
 }
@@ -608,27 +608,27 @@ void UtSensorAnalog::testNoise()
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify the noise output with no malfunction.
-    article.mSensedOutput        = 10.0;
-    article.mMalfNoiseScale      = 0.5;
-    article.mMalfNoiseMultiplier = 0.1;
-    float expected = 10.0 + tNominalNoiseScale * UtSensorAnalogNoise::testNoise()
-                   + tNominalNoiseMult * UtSensorAnalogNoise::testNoise() * std::fabs(10.0 - tOffValue);
+    article.mSensedOutput        = 10.0F;
+    article.mMalfNoiseScale      = 0.5F;
+    article.mMalfNoiseMultiplier = 0.1F;
+    float expected = 10.0F + tNominalNoiseScale * static_cast<float>(UtSensorAnalogNoise::testNoise())
+                   + tNominalNoiseMult * static_cast<float>(UtSensorAnalogNoise::testNoise()) * std::fabs(10.0F - tOffValue);
     article.applyNoise();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the noise output with malfunction.
-    article.mSensedOutput        = 10.0;
+    article.mSensedOutput        = 10.0F;
     article.mMalfNoiseFlag       = true;
-    expected                     = 10.0 + 0.5 * UtSensorAnalogNoise::testNoise()
-                                 + 0.1 * UtSensorAnalogNoise::testNoise() * std::fabs(10.0 - tOffValue);
+    expected                     = 10.0F + 0.5F * static_cast<float>(UtSensorAnalogNoise::testNoise())
+                                 + 0.1F * static_cast<float>(UtSensorAnalogNoise::testNoise()) * std::fabs(10.0F - tOffValue);
     article.applyNoise();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the noise output with noise scales zero.
-    article.mSensedOutput        = 10.0;
-    article.mMalfNoiseScale      = 0.0;
-    article.mMalfNoiseMultiplier = 0.0;
-    expected                     = 10.0;
+    article.mSensedOutput        = 10.0F;
+    article.mMalfNoiseScale      = 0.0F;
+    article.mMalfNoiseMultiplier = 0.0F;
+    expected                     = 10.0F;
     article.applyNoise();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
@@ -638,11 +638,11 @@ void UtSensorAnalog::testNoise()
     CPPUNIT_ASSERT_NO_THROW(article2.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify the noise output with no noise function.
-    article2.mSensedOutput       = 10.0;
+    article2.mSensedOutput       = 10.0F;
     article2.mMalfNoiseFlag      = true;
-    article2.mMalfNoiseScale     = 0.5;
-    article.mMalfNoiseMultiplier = 0.1;
-    expected                     = 10.0;
+    article2.mMalfNoiseScale     = 0.5F;
+    article.mMalfNoiseMultiplier = 0.1F;
+    expected                     = 10.0F;
     article2.applyNoise();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article2.mSensedOutput, FLT_EPSILON);
 
@@ -667,49 +667,49 @@ void UtSensorAnalog::testResolution()
 
     /// - Verify the resolution output with no malfunction.  The nominal quantize scale is set to
     ///   0.2, so this case should round downwards.
-    article.mSensedOutput   = 10.05;
-    float expected          = 10.0;
+    article.mSensedOutput   = 10.05F;
+    float expected          = 10.0F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify the rounding up case.
-    article.mSensedOutput   = 10.15;
-    expected                = 10.2;
+    article.mSensedOutput   = 10.15F;
+    expected                = 10.2F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify a negative value case, rounding down.
-    article.mSensedOutput   = -10.15;
-    expected                = -10.2;
+    article.mSensedOutput   = -10.15F;
+    expected                = -10.2F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify a negative value case, rounding up.
-    article.mSensedOutput   = -10.05;
-    expected                = -10.0;
+    article.mSensedOutput   = -10.05F;
+    expected                = -10.0F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify a negative value gets used as positive.
-    article.mSensedOutput         = -10.15;
-    article.mNominalResolution    =  -0.2;
-    expected                      = -10.2;
+    article.mSensedOutput         = -10.15F;
+    article.mNominalResolution    =  -0.2F;
+    expected                      = -10.2F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify zero value.
-    article.mSensedOutput         = 10.15;
-    article.mNominalResolution    =  0.0;
-    expected                      = 10.15;
+    article.mSensedOutput         = 10.15F;
+    article.mNominalResolution    =  0.0F;
+    expected                      = 10.15F;
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
     /// - Verify malfunction overrides the nominal value.
-    article.mSensedOutput         = 10.15;
-    article.mNominalResolution    =  0.2;
+    article.mSensedOutput         = 10.15F;
+    article.mNominalResolution    =  0.2F;
     article.mMalfResolutionFlag   = true;
-    article.mMalfResolutionValue  =  0.18;
-    expected                      = 10.08;  // int (10.15/0.18) * 0.18
+    article.mMalfResolutionValue  =  0.18F;
+    expected                      = 10.08F;  // int (10.15/0.18) * 0.18
     article.applyResolution();
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
 
@@ -729,39 +729,39 @@ void UtSensorAnalog::testUpdateNominal()
 
     /// - Set up a test article with nominal config & input data.
     FriendlySensorAnalog article;
-    tNominalConfig->mNominalResolution = 0.18;
+    tNominalConfig->mNominalResolution = 0.18F;
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Based on the nominal config & input data, verify the sensor output.
-    float expected = tTruthInput * tNominalScale + tNominalBias + tNominalNoiseScale;
-    expected = 0.18 * static_cast<double>(round(expected/0.18));
+    float expected = static_cast<float>(tTruthInput) * tNominalScale + tNominalBias + tNominalNoiseScale;
+    expected = 0.18F * std::round(expected/0.18F);
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
     CPPUNIT_ASSERT(false == article.mDegradedFlag);
 
     /// - Verify the lower output limit.
-    article.setTruthInput(tMinRange - 5.0);
+    article.setTruthInput(static_cast<double>(tMinRange) - 5.0);
     expected = tMinRange;
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
 
     /// - Verify the upper output limit.
-    article.setTruthInput(tMaxRange + 5.0);
+    article.setTruthInput(static_cast<double>(tMaxRange) + 5.0);
     expected = tMaxRange;
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
 
     /// - Verify protection against underflow in the input.
     article.setTruthInput(DBL_MIN);
-    article.mMinRange          =-1.0;
-    article.mNominalResolution = 0.0;
-    article.mNominalBias       = 0.0;
-    article.mNominalScale      = 1.0;
-    article.mNominalNoiseScale = 0.0;
-    article.mNominalNoiseMult  = 0.0;
-    expected = 0.0;
+    article.mMinRange          =-1.0F;
+    article.mNominalResolution = 0.0F;
+    article.mNominalBias       = 0.0F;
+    article.mNominalScale      = 1.0F;
+    article.mNominalNoiseScale = 0.0F;
+    article.mNominalNoiseMult  = 0.0F;
+    expected = 0.0F;
     article.update(tTimeStep);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, 0.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, 0.0F);
 
     std::cout << "... Pass";
 }
@@ -833,8 +833,8 @@ void UtSensorAnalog::testMalfStuck()
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Verify nominal sensed output of sensor.
-    float expected = tTruthInput * tNominalScale + tNominalBias + tNominalNoiseScale;
-    expected = tNominalResolution * static_cast<double>(round(expected/tNominalResolution));
+    float expected = static_cast<float>(tTruthInput) * tNominalScale + tNominalBias + tNominalNoiseScale;
+    expected = tNominalResolution * std::round(expected/tNominalResolution);
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
 
@@ -847,8 +847,8 @@ void UtSensorAnalog::testMalfStuck()
 
     /// - Remove the malf and verify the sensor goes back to the new truth value.
     article.mMalfFailStuckFlag = false;
-    expected = article.getTruthInput() * tNominalScale + tNominalBias + tNominalNoiseScale;
-    expected = tNominalResolution * static_cast<double>(round(expected/tNominalResolution));
+    expected = static_cast<float>(article.getTruthInput()) * tNominalScale + tNominalBias + tNominalNoiseScale;
+    expected = tNominalResolution * std::round(expected/tNominalResolution);
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON * expected);
     CPPUNIT_ASSERT(false == article.mDegradedFlag);
@@ -880,14 +880,14 @@ void UtSensorAnalog::testMalfPerfect()
     /// - Verify the perfect sensor malf overrides power.
     article.mMalfPerfectSensor = true;
     article.update(tTimeStep);
-    expected = tTruthInput;
+    expected = static_cast<float>(tTruthInput);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
     CPPUNIT_ASSERT(false == article.mDegradedFlag);
 
     /// - Verify the perfect sensor malf overrides the stuck malf.
     article.mMalfFailStuckFlag = true;
     article.setTruthInput(20.0);
-    expected = 20.0;
+    expected = 20.0F;
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, FLT_EPSILON);
     CPPUNIT_ASSERT(false == article.mDegradedFlag);
@@ -929,8 +929,8 @@ void UtSensorAnalog::testMalfInteractions()
     article.setPowerFlag(true);
     article.mMalfFailStuckFlag = true;
     article.mMalfFailToFlag    = true;
-    article.mMalfFailToValue   = 15.0;
-    expected                   = 15.0;
+    article.mMalfFailToValue   = 15.0F;
+    expected                   = 15.0F;
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.getSensedOutput(), FLT_EPSILON);
     CPPUNIT_ASSERT(true  == article.mDegradedFlag);
@@ -955,18 +955,18 @@ void UtSensorAnalog::testMalfInteractions()
 
     /// - Verify the interaction of the scale, bias, drift, noise & quantization malfunctions.
     article2.mMalfScaleFlag       = true;
-    article2.mMalfScaleValue      = 1.2;
+    article2.mMalfScaleValue      = 1.2F;
     article2.mMalfBiasFlag        = true;
-    article2.mMalfBiasValue       = -0.6;
+    article2.mMalfBiasValue       = -0.6F;
     article2.mMalfDriftFlag       = true;
-    article2.mMalfDriftRate       = 0.05;
+    article2.mMalfDriftRate       = 0.05F;
     article2.mMalfNoiseFlag       = true;
-    article2.mMalfNoiseScale      = 5.0;
+    article2.mMalfNoiseScale      = 5.0F;
     article2.mMalfResolutionFlag  = true;
-    article2.mMalfResolutionValue = 0.175;
-    expected = tTruthInput * tNominalScale * 1.2 + tNominalBias - 0.6 + 0.05 * tTimeStep +
-               tNominalNoiseScale * 5.0;
-    expected = 0.175 * static_cast<double>(round(expected/0.175));
+    article2.mMalfResolutionValue = 0.175F;
+    expected = static_cast<float>(tTruthInput) * tNominalScale * 1.2F + tNominalBias - 0.6F +
+               0.05F * static_cast<float>(tTimeStep) + tNominalNoiseScale * 5.0F;
+    expected = 0.175F * std::round(expected/0.175F);
     article2.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article2.getSensedOutput(), FLT_EPSILON * expected);
     CPPUNIT_ASSERT(true  == article.mDegradedFlag);
@@ -992,7 +992,7 @@ void UtSensorAnalog::testExternalNoiseFunctions()
 
     /// - Step the sensor to call the TS_noise function.  We just need to verify this configuration
     ///   compiles and runs, but check each value to make sure it is within the noise scale.
-    float expected = tTruthInput * tNominalScale + tNominalBias;
+    float expected = static_cast<float>(tTruthInput) * tNominalScale + tNominalBias;
     article.update(tTimeStep);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, article.mSensedOutput, tNominalNoiseScale);
     article.update(tTimeStep);
@@ -1014,12 +1014,12 @@ void UtSensorAnalog::testSense()
 
     /// - Set up a test article with nominal config & input data.
     FriendlySensorAnalog article;
-    tNominalConfig->mNominalResolution = 0.18;
+    tNominalConfig->mNominalResolution = 0.18F;
     CPPUNIT_ASSERT_NO_THROW(article.initialize(*tNominalConfig, *tNominalInput, tName.c_str()));
 
     /// - Based on the nominal config & input data, verify the sensor output.
-    float expected = tTruthInput * tNominalScale + tNominalBias + tNominalNoiseScale;
-    expected = 0.18 * static_cast<double>(round(expected/0.18));
+    float expected = static_cast<float>(tTruthInput) * tNominalScale + tNominalBias + tNominalNoiseScale;
+    expected = 0.18F * std::round(expected/0.18F);
     const float result = article.sense(tTimeStep, true, tTruthInput);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, result, FLT_EPSILON * expected);
 

--- a/gunns-ts-models/common/sensors/test/UtSensorBooleanAi.cpp
+++ b/gunns-ts-models/common/sensors/test/UtSensorBooleanAi.cpp
@@ -61,11 +61,11 @@ void UtSensorBooleanAi::testConfigData()
     /// - Test default construction of a test config data article.
     SensorBooleanAiConfigData defaultConfig;
     CPPUNIT_ASSERT(false == defaultConfig.mOffValue);
-    CPPUNIT_ASSERT(0.0   == defaultConfig.mTarget);
-    CPPUNIT_ASSERT(0.0   == defaultConfig.mTolerance);
+    CPPUNIT_ASSERT(0.0F  == defaultConfig.mTarget);
+    CPPUNIT_ASSERT(0.0F  == defaultConfig.mTolerance);
 
     /// - Test nominal construction of a test config data article.
-    SensorBooleanAiConfigData nominalConfig(true, 0.9, 0.1);
+    SensorBooleanAiConfigData nominalConfig(true, 0.9F, 0.1F);
     CPPUNIT_ASSERT(true          == nominalConfig.mOffValue);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.9, nominalConfig.mTarget,    FLT_EPSILON);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.1, nominalConfig.mTolerance, FLT_EPSILON);
@@ -106,7 +106,7 @@ void UtSensorBooleanAi::testInputData()
     CPPUNIT_ASSERT(false == defaultInput.mMalfPerfectSensor);
     CPPUNIT_ASSERT(false == defaultInput.mTruthInput);
     CPPUNIT_ASSERT(false == defaultInput.mMalfFailToValue);
-    CPPUNIT_ASSERT(0.0   == defaultInput.mTruthInputAnalog);
+    CPPUNIT_ASSERT(0.0F  == defaultInput.mTruthInputAnalog);
 
     /// - Test nominal construction of a test input data article.
     SensorBooleanAiInputData nominalInput(true, true, 0.5);
@@ -179,8 +179,8 @@ void UtSensorBooleanAi::testConstruction()
     CPPUNIT_ASSERT(false == tArticle.mSensedOutput);
 
     /// - Test default construction of the test article.
-    CPPUNIT_ASSERT(0.0   == tArticle.mTarget);
-    CPPUNIT_ASSERT(0.0   == tArticle.mTolerance);
+    CPPUNIT_ASSERT(0.0F  == tArticle.mTarget);
+    CPPUNIT_ASSERT(0.0F  == tArticle.mTolerance);
     CPPUNIT_ASSERT(0.0   == tArticle.mTruthInputAnalog);
 
     std::cout << "... Pass";
@@ -194,8 +194,8 @@ void UtSensorBooleanAi::testInitialize()
     std::cout << "\n UtSensorBooleanAi .... 04: testInitialize.............................";
 
     /// - Define nominal config & input data.
-    SensorBooleanAiConfigData nominalConfig(true, 0.9, 0.1);
-    SensorBooleanAiInputData  nominalInput(true, true, 0.89);
+    SensorBooleanAiConfigData nominalConfig(true, 0.9F, 0.1F);
+    SensorBooleanAiInputData  nominalInput(true, true, 0.89F);
 
     /// - Test nominal initialization of the test article base classes.
     CPPUNIT_ASSERT_NO_THROW(tArticle.initialize(nominalConfig, nominalInput, tName.c_str()));
@@ -230,8 +230,8 @@ void UtSensorBooleanAi::testInitializeExceptions()
     std::cout << "\n UtSensorBooleanAi .... 05: testInitializeExceptions...................";
 
     /// - Verify exception is thrown when tolerance is < 0.
-    SensorBooleanAiConfigData nominalConfig(true, 0.9, -0.01);
-    SensorBooleanAiInputData  nominalInput(true, true, 0.89);
+    SensorBooleanAiConfigData nominalConfig(true, 0.9F, -0.01F);
+    SensorBooleanAiInputData  nominalInput(true, true, 0.89F);
     CPPUNIT_ASSERT_THROW(tArticle.initialize(nominalConfig, nominalInput, tName.c_str()),
                          TsInitializationException);
 
@@ -249,8 +249,8 @@ void UtSensorBooleanAi::testAccessors()
     std::cout << "\n UtSensorBooleanAi .... 06: testAccessors..............................";
 
     /// - Set up a test article with nominal config & input data.
-    SensorBooleanAiConfigData nominalConfig(false, 0.9, 0.1);
-    SensorBooleanAiInputData  nominalInput(false, false, 0.5);
+    SensorBooleanAiConfigData nominalConfig(false, 0.9F, 0.1F);
+    SensorBooleanAiInputData  nominalInput(false, false, 0.5F);
     tArticle.initialize(nominalConfig, nominalInput, tName.c_str());
 
     /// - Test the methods to set and get the input truth analog value.
@@ -274,8 +274,8 @@ void UtSensorBooleanAi::testUpdateNominal()
     std::cout << "\n UtSensorBooleanAi .... 07: testUpdateNominal..........................";
 
     /// - Set up a test article with nominal config & input data.
-    SensorBooleanAiConfigData nominalConfig(false, 0.9, 0.1);
-    SensorBooleanAiInputData  nominalInput(true, false, 0.5);
+    SensorBooleanAiConfigData nominalConfig(false, 0.9F, 0.1F);
+    SensorBooleanAiInputData  nominalInput(true, false, 0.5F);
     tArticle.initialize(nominalConfig, nominalInput, tName.c_str());
 
     /// - The following tests verify the output of the sensor when the truth input is in different
@@ -286,7 +286,7 @@ void UtSensorBooleanAi::testUpdateNominal()
     CPPUNIT_ASSERT(false == tArticle.getSensedOutput());
 
     /// - Verify: truth input = target - tolerance (within precision limits).
-    tArticle.setTruthInput(0.8 + FLT_EPSILON);
+    tArticle.setTruthInput(0.8F + FLT_EPSILON);
     tArticle.update(0.0);
     CPPUNIT_ASSERT(true  == tArticle.getSensedOutput());
 
@@ -301,7 +301,7 @@ void UtSensorBooleanAi::testUpdateNominal()
     CPPUNIT_ASSERT(true  == tArticle.getSensedOutput());
 
     /// - Verify: truth input = target + tolerance (within precision limits).
-    tArticle.setTruthInput(1.0 - FLT_EPSILON);
+    tArticle.setTruthInput(1.0F - FLT_EPSILON);
     tArticle.update(0.0);
     CPPUNIT_ASSERT(true  == tArticle.getSensedOutput());
 
@@ -321,12 +321,12 @@ void UtSensorBooleanAi::testSense()
     std::cout << "\n UtSensorBooleanAi .... 08: testSense..................................";
 
     /// - Set up a test article with nominal config & input data.
-    SensorBooleanAiConfigData nominalConfig(false, 0.9, 0.1);
-    SensorBooleanAiInputData  nominalInput(true, false, 0.5);
+    SensorBooleanAiConfigData nominalConfig(false, 0.9F, 0.1F);
+    SensorBooleanAiInputData  nominalInput(true, false, 0.5F);
     tArticle.initialize(nominalConfig, nominalInput, tName.c_str());
 
     /// - Verify: truth input = target - tolerance (within precision limits).
-    CPPUNIT_ASSERT(tArticle.sense(0.0, true, 0.8 + FLT_EPSILON));
+    CPPUNIT_ASSERT(tArticle.sense(0.0, true, 0.8 + static_cast<double>(FLT_EPSILON)));
 
     std::cout << "... Pass.";
     std::cout << "\n--------------------------------------------------------------------------------";

--- a/gunns-ts-models/common/sensors/test/UtTsOpticSmokeDetector.cpp
+++ b/gunns-ts-models/common/sensors/test/UtTsOpticSmokeDetector.cpp
@@ -49,35 +49,35 @@ UtTsOpticSmokeDetector::~UtTsOpticSmokeDetector()
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 void UtTsOpticSmokeDetector::setUp()
 {
-    dt                               = 0.1;
+    dt                               = 0.1F;
     sdName                           = "Smoke Detector Test";
 
-    configData.obsMaxPercentage      = 104.12; // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.obsMinPercentage      = 0.0;    // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.obsSmokeContributer   = 20.0;   //Tunes the obscuration smoke contribution according to JMEWS.
-    configData.scatterMaxPercentage  = 2.47;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.scatterMinPercentage  = 0.11;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.bitOnMaxScatterValue  = 1.42;   // %/ft. JMEWS Data. Ref. SSP 41002 Table 3.3.4.1.1.3-1 for ISS SD.
-    configData.nominalObscuration    = 8.24;   // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.nominalScatter        = 0.16;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
-    configData.bitRecoveryTime       = 1.5;    // sec.  D684-10508-02-02: Sec. 3.3 for ISS SD: "Quite Period".
+    configData.obsMaxPercentage      = 104.12F; // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.obsMinPercentage      = 0.0F;    // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.obsSmokeContributer   = 20.0F;   //Tunes the obscuration smoke contribution according to JMEWS.
+    configData.scatterMaxPercentage  = 2.47F;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.scatterMinPercentage  = 0.11F;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.bitOnMaxScatterValue  = 1.42F;   // %/ft. JMEWS Data. Ref. SSP 41002 Table 3.3.4.1.1.3-1 for ISS SD.
+    configData.nominalObscuration    = 8.24F;   // Obs.% JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.nominalScatter        = 0.16F;   // %/ft. JMEWS Data. Ref. D684-10508-02-02: Sec. 3.3 for ISS SD.
+    configData.bitRecoveryTime       = 1.5F;    // sec.  D684-10508-02-02: Sec. 3.3 for ISS SD: "Quite Period".
 
     inputData.isPowered              = false;
     inputData.isLoadOn               = 1;
     inputData.isBitEnabled           = false;
-    inputData.smokeLevelFactor       = 0.0;
-    inputData.bitTimer               = 0.0;
+    inputData.smokeLevelFactor       = 0.0F;
+    inputData.bitTimer               = 0.0F;
 
     //obscuration sensor
-    configData.obsSensorConfigD.mMinRange              = 0.0;    // Obs.%
-    configData.obsSensorConfigD.mMaxRange              = 104.15; // Obs.%
-    configData.obsSensorConfigD.mNominalNoiseScale     = 0.5;
+    configData.obsSensorConfigD.mMinRange              = 0.0F;    // Obs.%
+    configData.obsSensorConfigD.mMaxRange              = 104.15F; // Obs.%
+    configData.obsSensorConfigD.mNominalNoiseScale     = 0.5F;
     configData.obsSensorConfigD.mNoiseFunction         = TsNoise::getNoise;
 
     //scatter sensor
-    configData.scatterSensorConfigD.mMinRange          = 0.0;    // %/ft
-    configData.scatterSensorConfigD.mMaxRange          = 2.47;   // %/ft
-    configData.scatterSensorConfigD.mNominalNoiseScale = 0.05;
+    configData.scatterSensorConfigD.mMinRange          = 0.0F;    // %/ft
+    configData.scatterSensorConfigD.mMaxRange          = 2.47F;   // %/ft
+    configData.scatterSensorConfigD.mNominalNoiseScale = 0.05F;
     configData.scatterSensorConfigD.mNoiseFunction     = TsNoise::getNoise;
 
     test  = new TsOpticSmokeDetector();
@@ -418,7 +418,7 @@ void UtTsOpticSmokeDetector::RunUpdateNominallyWithSmokeTest()
     std::cout << "\n Optic Smoke Detector: Verify outputs with nominal conditions and smoke added in to the system.";
 
     inputData.isPowered = true;
-    inputData.smokeLevelFactor = 0.9;
+    inputData.smokeLevelFactor = 0.9F;
 
     testArticle.initialize(configData, inputData, sdName);
 
@@ -429,12 +429,12 @@ void UtTsOpticSmokeDetector::RunUpdateNominallyWithSmokeTest()
     float obsVoltValue     = obscurationValue * configData.obsPercentVoltSlope + configData.obsVoltIntercept;
     float scatVoltValue    = scatterValue * configData.scatPercentVoltSlope + configData.scatVoltIntercept;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obsVoltValue,     testArticle.obsSensedVoltage, 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatVoltValue,    testArticle.scatSensedVoltage, 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obsVoltValue,     testArticle.obsSensedVoltage, 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatVoltValue,    testArticle.scatSensedVoltage, 0.05F);
 
     std::cout << "\t... Pass";
 }
@@ -459,10 +459,10 @@ void UtTsOpticSmokeDetector::RunUpdateWithPowerMalfunctionsTest()
     float obscurationValue = configData.nominalObscuration;
     float scatterValue     = configData.nominalScatter;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
     CPPUNIT_ASSERT_EQUAL(1,  testArticle.isLoadOn);
 
     std::cout << "\t... Pass";
@@ -478,8 +478,8 @@ void UtTsOpticSmokeDetector::RunUpdateWithNoPowerTest()
     inputData.isPowered       = false;
     testArticle.malfPowerToOn = false;
     testArticle.malfTotalFail = false;
-    configData.obsOffValue    = 53.45;
-    configData.scatOffValue   = 0.1006;
+    configData.obsOffValue    = 53.45F;
+    configData.scatOffValue   = 0.1006F;
     float obsVoltValue        = configData.obsOffValue * configData.obsPercentVoltSlope + configData.obsVoltIntercept;
     float scatVoltValue       = configData.scatOffValue * configData.scatPercentVoltSlope + configData.scatVoltIntercept;
 
@@ -488,12 +488,12 @@ void UtTsOpticSmokeDetector::RunUpdateWithNoPowerTest()
     testArticle.update(dt);
 
     CPPUNIT_ASSERT_EQUAL(0,              testArticle.isLoadOn);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.obsOffValue,  testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.scatOffValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.obsOffValue,  testArticle.getSensedObscurationValue(), 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.scatOffValue, testArticle.getSensedScatterValue(), 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obsVoltValue,     testArticle.obsSensedVoltage, 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatVoltValue,    testArticle.scatSensedVoltage, 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.obsOffValue,  testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.scatOffValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.obsOffValue,  testArticle.getSensedObscurationValue(), 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(configData.scatOffValue, testArticle.getSensedScatterValue(), 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obsVoltValue,     testArticle.obsSensedVoltage, 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatVoltValue,    testArticle.scatSensedVoltage, 0.05F);
 
     std::cout << "\t... Pass";
 }
@@ -515,10 +515,10 @@ void UtTsOpticSmokeDetector::RunUpdateWithFailCommandTest()
 
     testArticle.update(dt);
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(53.45,   testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.1006,  testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(53.45,   testArticle.getSensedObscurationValue(), 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.10060, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(53.45F,   testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.1006F,  testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(53.45F,   testArticle.getSensedObscurationValue(), 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.10060F, testArticle.getSensedScatterValue(), 0.05F);
 
     std::cout << "\t... Pass";
 }
@@ -541,8 +541,8 @@ void UtTsOpticSmokeDetector::RunUpdateWithFailedObscurationSensorTest()
 
     float obscurationValue = configData.nominalObscuration;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.05);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, testArticle.getSensedObscurationValue(), 1.0);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.05F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0F, testArticle.getSensedObscurationValue(), 1.0F);
 
     std::cout << "\t... Pass";
 }
@@ -556,7 +556,7 @@ void UtTsOpticSmokeDetector::RunUpdateWithFailedScatterSensorTest()
 
     inputData.isPowered = true;
     //Malf
-    inputData.scatterSensorInputD.mMalfFailToValue = 0.0;
+    inputData.scatterSensorInputD.mMalfFailToValue = 0.0F;
     inputData.scatterSensorInputD.mMalfScaleFlag = true;
 
     testArticle.initialize(configData, inputData, sdName);
@@ -565,8 +565,8 @@ void UtTsOpticSmokeDetector::RunUpdateWithFailedScatterSensorTest()
 
     float scatterValue     = configData.nominalScatter;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0F, testArticle.getSensedScatterValue(), 0.05F);
 
     std::cout << "\t... Pass";
 }
@@ -594,10 +594,10 @@ void UtTsOpticSmokeDetector::RunActiveBitTest()
     float obscurationValue = configData.obsMaxPercentage;
     float scatterValue     = configData.bitOnMaxScatterValue;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
 
     testArticle.isBitEnabled = false;
     for(int ii = 0; ii < 16; ii++)
@@ -608,20 +608,20 @@ void UtTsOpticSmokeDetector::RunActiveBitTest()
     obscurationValue = configData.obsMaxPercentage;
     scatterValue     = configData.scatterMinPercentage;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.06);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.06F);
 
     testArticle.update(dt); //After bitTimer exceeds bit recovery time, sensor has finished active bit test.
 
     obscurationValue = configData.nominalObscuration;
     scatterValue     = configData.nominalScatter;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.06);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.06F);
 
     std::cout << "\t... Pass";
 }
@@ -635,7 +635,7 @@ void UtTsOpticSmokeDetector::RunActiveBitWithSmokeTest()
 
     inputData.isPowered                 = true;
     inputData.isBitEnabled              = true;
-    inputData.smokeLevelFactor          = 0.9;
+    inputData.smokeLevelFactor          = 0.9F;
     testArticle.malfTotalFail           = false;
     testArticle.malfPowerToOn           = false;
 
@@ -649,10 +649,10 @@ void UtTsOpticSmokeDetector::RunActiveBitWithSmokeTest()
     float obscurationValue = configData.obsMaxPercentage;
     float scatterValue     = configData.bitOnMaxScatterValue;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
 
     testArticle.isBitEnabled = false;
     for(int ii = 0; ii < 16; ii++)
@@ -663,21 +663,20 @@ void UtTsOpticSmokeDetector::RunActiveBitWithSmokeTest()
     obscurationValue = configData.obsMaxPercentage;
     scatterValue     = configData.scatterMinPercentage;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
 
     testArticle.update(dt); //After bitTimer exceeds bit recovery time, sensor has finished active bit test, goes back to normal.
 
     obscurationValue = configData.nominalObscuration + (configData.obsSmokeContributer * inputData.smokeLevelFactor);
     scatterValue     = configData.nominalScatter + (configData.scatterMaxPercentage - configData.nominalScatter) * inputData.smokeLevelFactor;
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.obscurationPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.scatterPercentage, 0.01F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(obscurationValue, testArticle.getSensedObscurationValue(), 1.0F);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(scatterValue, testArticle.getSensedScatterValue(), 0.05F);
 
     std::cout << "\t... Pass";
 }
-

--- a/ms-utils/math/approximation/test/UtTsCurveFit.cpp
+++ b/ms-utils/math/approximation/test/UtTsCurveFit.cpp
@@ -487,8 +487,8 @@ void UtTsCurveFit::testQuadraticRootFit()
 
     mArticle = new QuadraticRootFit(a, b, minX, maxX);
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->get(x), FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->getExceptional(x), FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->get(x), static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, mArticle->getExceptional(x), static_cast<double>(FLT_EPSILON));
 
     delete article;
 
@@ -506,8 +506,8 @@ void UtTsCurveFit::testCoefficientAccessors()
     const double b = 1.785E-001;
     LinearFit article(a, b, 1.0, 500.0);
 
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(a, article.getA(), FLT_EPSILON);
-    CPPUNIT_ASSERT_DOUBLES_EQUAL(b, article.getB(), FLT_EPSILON);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(a, article.getA(), static_cast<double>(FLT_EPSILON));
+    CPPUNIT_ASSERT_DOUBLES_EQUAL(b, article.getB(), static_cast<double>(FLT_EPSILON));
 
     std::cout << "... Pass";
 }
@@ -805,7 +805,7 @@ void UtTsCurveFit::testExponentialException()
     const double b = +2.0;
     const double c = +3.0;
     const double minX = -1000.0;
-    const double maxX = -0.5 * FLT_EPSILON;
+    const double maxX = -0.5 * static_cast<double>(FLT_EPSILON);
 
     CPPUNIT_ASSERT_THROW(new ExponentialFit(a, b, c, minX, maxX), TsInitializationException);
     CPPUNIT_ASSERT_THROW(new ExponentialFit(a, b, c, -maxX, -minX), TsInitializationException);
@@ -828,11 +828,11 @@ void UtTsCurveFit::testRationalException()
     const double minX = -1000.0;
     const double maxX = +1000.0;
 
-    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, c - FLT_EPSILON / 2, d, minX, maxX),
+    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, c - static_cast<double>(FLT_EPSILON) / 2, d, minX, maxX),
         TsInitializationException);
-    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, -c + FLT_EPSILON / 2, d, minX, maxX),
+    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, -c + static_cast<double>(FLT_EPSILON) / 2, d, minX, maxX),
         TsInitializationException);
-    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, 0.0, FLT_EPSILON / 256.0, minX, maxX),
+    CPPUNIT_ASSERT_THROW(new RationalFit(a, b, 0.0, static_cast<double>(FLT_EPSILON) / 256.0, minX, maxX),
         TsInitializationException);
 
     std::cout << "... Pass";
@@ -850,16 +850,16 @@ void UtTsCurveFit::testInvLinearException()
     const double b = 0.0;
     const double c = -1000.0;
 
-    double minX = FLT_EPSILON * 0.5;
+    double minX = static_cast<double>(FLT_EPSILON) * 0.5;
     double maxX = 1000.0;
     CPPUNIT_ASSERT_THROW(new InvLinearFit(a, b, c, minX, maxX), TsInitializationException);
 
     minX = -1000.0;
-    maxX = -FLT_EPSILON * 0.5;
+    maxX = -static_cast<double>(FLT_EPSILON) * 0.5;
     CPPUNIT_ASSERT_THROW(new InvLinearFit(a, b, c, -maxX, -minX), TsInitializationException);
 
-    minX = -0.5 * FLT_EPSILON;
-    maxX = +0.5 * FLT_EPSILON;
+    minX = -0.5 * static_cast<double>(FLT_EPSILON);
+    maxX = +0.5 * static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(new InvLinearFit(a, b, c, -maxX, -minX), TsInitializationException);
 
     std::cout << "... Pass";
@@ -877,16 +877,16 @@ void UtTsCurveFit::testInvQuadraticException()
     const double b = +2.0;
     const double c = +3.0;
 
-    double minX = FLT_EPSILON * 0.5;
+    double minX = static_cast<double>(FLT_EPSILON) * 0.5;
     double maxX = 1000.0;
     CPPUNIT_ASSERT_THROW(new InvQuadraticFit(a, b, c, minX, maxX), TsInitializationException);
 
     minX = -1000.0;
-    maxX = -FLT_EPSILON * 0.5;
+    maxX = -static_cast<double>(FLT_EPSILON) * 0.5;
     CPPUNIT_ASSERT_THROW(new InvQuadraticFit(a, b, c, -maxX, -minX), TsInitializationException);
 
-    minX = -0.5 * FLT_EPSILON;
-    maxX = +0.5 * FLT_EPSILON;
+    minX = -0.5 * static_cast<double>(FLT_EPSILON);
+    maxX = +0.5 * static_cast<double>(FLT_EPSILON);
     CPPUNIT_ASSERT_THROW(new InvQuadraticFit(a, b, c, -maxX, -minX), TsInitializationException);
 
     std::cout << "... Pass";
@@ -905,8 +905,8 @@ void UtTsCurveFit::testShowmateException()
     const double c = +3.0;
     const double d = +4.0;
     const double e = +5.0;
-    const double minX = -2.0 * FLT_EPSILON;
-    const double maxX = +0.5 * FLT_EPSILON;
+    const double minX = -2.0 * static_cast<double>(FLT_EPSILON);
+    const double maxX = +0.5 * static_cast<double>(FLT_EPSILON);
 
     CPPUNIT_ASSERT_THROW(new ShowmateFit(a, b, c, d, e, minX, maxX), TsInitializationException);
     CPPUNIT_ASSERT_THROW(new ShowmateFit(a, b, c, d, e, -maxX, -minX), TsInitializationException);
@@ -924,8 +924,8 @@ void UtTsCurveFit::testSutherlandException()
 
     const double a = +1.0;
     const double b = +0.0;
-    double minX = -0.5 * FLT_EPSILON;
-    double maxX = +0.5 * FLT_EPSILON;
+    double minX = -0.5 * static_cast<double>(FLT_EPSILON);
+    double maxX = +0.5 * static_cast<double>(FLT_EPSILON);
 
     CPPUNIT_ASSERT_THROW(new SutherlandFit(a, b, minX, maxX), TsInitializationException);
 
@@ -941,18 +941,18 @@ void UtTsCurveFit::testQuotientException()
     std::cout << "\n Curve Fit 28: Bivariate Quotient Initialization Exception Test         ";
 
     const double a = 1.0;
-    double minX = FLT_EPSILON * 0.1;
+    double minX = static_cast<double>(FLT_EPSILON) * 0.1;
     double maxX = +1000.0;
     double minY = -1000.0;
     double maxY = +1000.0;
     CPPUNIT_ASSERT_THROW(new QuotientFit(a, minX, maxX, minY, maxY), TsInitializationException);
 
     minX = -1000.0;
-    maxX = -FLT_EPSILON * 0.1;
+    maxX = -static_cast<double>(FLT_EPSILON) * 0.1;
     CPPUNIT_ASSERT_THROW(new QuotientFit(a, minX, maxX, minY, maxY), TsInitializationException);
 
-    minX = -FLT_EPSILON * 0.1;
-    maxX = +FLT_EPSILON * 0.1;
+    minX = -static_cast<double>(FLT_EPSILON) * 0.1;
+    maxX = +static_cast<double>(FLT_EPSILON) * 0.1;
     CPPUNIT_ASSERT_THROW(new QuotientFit(a, minX, maxX, minY, maxY), TsInitializationException);
 
     std::cout << "... Pass";
@@ -968,10 +968,10 @@ void UtTsCurveFit::testQuadLinInvException()
 
     const double a = 0.0;
     const double b = 0.0;
-    const double c = FLT_EPSILON;
+    const double c = static_cast<double>(FLT_EPSILON);
     const double d = 0.0;
     const double e = 0.0;
-    const double f = FLT_EPSILON;
+    const double f = static_cast<double>(FLT_EPSILON);
     const double minX = -1000.0;
     const double maxX = +1000.0;
     const double minY = -1000.0;

--- a/ms-utils/math/test/UtMath.cpp
+++ b/ms-utils/math/test/UtMath.cpp
@@ -106,8 +106,8 @@ void UtMath::testAnglePi()
     returned  = MsMath::anglePi(+2.5 * UnitConversion::PI_UTIL);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
-    expected  = UnitConversion::PI_UTIL - FLT_EPSILON;
-    returned  = MsMath::anglePi(+3.0 * UnitConversion::PI_UTIL - FLT_EPSILON);
+    expected  = UnitConversion::PI_UTIL - static_cast<double>(FLT_EPSILON);
+    returned  = MsMath::anglePi(+3.0 * UnitConversion::PI_UTIL - static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     std::cout << "Pass";
@@ -186,8 +186,8 @@ void UtMath::testAngle2Pi()
     returned  = MsMath::angle2Pi(+3.5 * UnitConversion::PI_UTIL);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
-    expected  = 2.0 * UnitConversion::PI_UTIL - FLT_EPSILON;
-    returned  = MsMath::angle2Pi(+4.0 * UnitConversion::PI_UTIL - FLT_EPSILON);
+    expected  = 2.0 * UnitConversion::PI_UTIL - static_cast<double>(FLT_EPSILON);
+    returned  = MsMath::angle2Pi(+4.0 * UnitConversion::PI_UTIL - static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     std::cout << "Pass";
@@ -250,8 +250,8 @@ void UtMath::testAngle180()
     returned  = MsMath::angle180(+2.5 * 180.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
-    expected  = +1.0 * 180.0 - FLT_EPSILON;
-    returned  = MsMath::angle180(+3.0 * 180.0 - FLT_EPSILON);
+    expected  = +1.0 * 180.0 - static_cast<double>(FLT_EPSILON);
+    returned  = MsMath::angle180(+3.0 * 180.0 - static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     std::cout << "Pass";
@@ -330,8 +330,8 @@ void UtMath::testAngle360()
     returned  = MsMath::angle360(+3.5 * 180.0);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
-    expected  = 2.0 * 180.0 - FLT_EPSILON;
-    returned  = MsMath::angle360(+4.0 * 180.0 - FLT_EPSILON);
+    expected  = 2.0 * 180.0 - static_cast<double>(FLT_EPSILON);
+    returned  = MsMath::angle360(+4.0 * 180.0 - static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     std::cout << "Pass";
@@ -355,8 +355,8 @@ void UtMath::testProtectedAsin()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument just within upper limit
-    expected  = std::asin(+1.0 - 2.0 * FLT_EPSILON);
-    returned  = MsMath::protectedAsin(+1.0 - 2.0 * FLT_EPSILON);
+    expected  = std::asin(+1.0 - 2.0 * static_cast<double>(FLT_EPSILON));
+    returned  = MsMath::protectedAsin(+1.0 - 2.0 * static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument well within limits
@@ -365,8 +365,8 @@ void UtMath::testProtectedAsin()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument just within lower limit
-    expected  = std::asin(-1.0 + 2.0 * FLT_EPSILON);
-    returned  = MsMath::protectedAsin(-1.0 + 2.0 * FLT_EPSILON);
+    expected  = std::asin(-1.0 + 2.0 * static_cast<double>(FLT_EPSILON));
+    returned  = MsMath::protectedAsin(-1.0 + 2.0 * static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument at lower limit
@@ -400,8 +400,8 @@ void UtMath::testProtectedAcos()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument just within upper limit
-    expected  = std::acos(+1.0 - 2.0 * FLT_EPSILON);
-    returned  = MsMath::protectedAcos(+1.0 - 2.0 * FLT_EPSILON);
+    expected  = std::acos(+1.0 - 2.0 * static_cast<double>(FLT_EPSILON));
+    returned  = MsMath::protectedAcos(+1.0 - 2.0 * static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument well within limits
@@ -410,8 +410,8 @@ void UtMath::testProtectedAcos()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument just within lower limit
-    expected  = std::acos(-1.0 + 2.0 * FLT_EPSILON);
-    returned  = MsMath::protectedAcos(-1.0 + 2.0 * FLT_EPSILON);
+    expected  = std::acos(-1.0 + 2.0 * static_cast<double>(FLT_EPSILON));
+    returned  = MsMath::protectedAcos(-1.0 + 2.0 * static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument at lower limit
@@ -441,7 +441,7 @@ void UtMath::testProtectedSqrt()
 
     /// @test for argument just within lower limit
     expected  = std::sqrt(static_cast<double>(FLT_EPSILON));
-    returned  = MsMath::protectedSqrt(FLT_EPSILON);
+    returned  = MsMath::protectedSqrt(static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument at lower limit
@@ -451,7 +451,7 @@ void UtMath::testProtectedSqrt()
 
     /// @test for argument just beyond lower limit
     expected  = 0.0;
-    returned  = MsMath::protectedSqrt(-FLT_EPSILON);
+    returned  = MsMath::protectedSqrt(-static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument well beyond lower limit
@@ -486,7 +486,7 @@ void UtMath::testProtectedLog10()
 
     /// @test for argument just beyond lower limit
     expected  = 0.0;
-    returned  = MsMath::protectedLog10(-FLT_EPSILON);
+    returned  = MsMath::protectedLog10(-static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument well beyond lower limit
@@ -511,7 +511,7 @@ void UtMath::testProtectedLog()
 
     /// @test for argument just within lower limit
     expected  = std::log(static_cast<double>(FLT_EPSILON));
-    returned  = MsMath::protectedLog(FLT_EPSILON);
+    returned  = MsMath::protectedLog(static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument at lower limit
@@ -521,7 +521,7 @@ void UtMath::testProtectedLog()
 
     /// @test for argument just beyond lower limit
     expected  = 0.0;
-    returned  = MsMath::protectedLog(-FLT_EPSILON);
+    returned  = MsMath::protectedLog(-static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for argument well beyond lower limit
@@ -564,63 +564,63 @@ void UtMath::testprotectedDiv()
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for negative denominator inside non-default threshold with default zero return value
-    den              = -FLT_EPSILON * 0.5;
+    den              = -static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  0.0;
-    returned         =  MsMath::protectedDiv(-1000.0, den, FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(-1000.0, den, static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for negative denominator outside non-default threshold with default zero return value
-    den              = -FLT_EPSILON * 2.0;
-    expected         = -0.5 / FLT_EPSILON;
-    returned         =  MsMath::protectedDiv(1.0, den, FLT_EPSILON);
+    den              = -static_cast<double>(FLT_EPSILON) * 2.0;
+    expected         = -0.5 / static_cast<double>(FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1.0, den, static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator inside non-default threshold with default zero return value
-    den              =  FLT_EPSILON * 0.5;
+    den              =  static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  0.0;
-    returned         =  MsMath::protectedDiv(1000.0, den, FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1000.0, den, static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator outside non-default threshold with default zero return value
-    den              =  FLT_EPSILON * 2.0;
-    expected         = -0.5 / FLT_EPSILON;
-    returned         =  MsMath::protectedDiv(-1.0, den, FLT_EPSILON);
+    den              =  static_cast<double>(FLT_EPSILON) * 2.0;
+    expected         = -0.5 / static_cast<double>(FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(-1.0, den, static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for negative denominator inside non-default threshold with non-default zero return value
-    den              = -FLT_EPSILON * 0.5;
+    den              = -static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  1.0;
-    returned         =  MsMath::protectedDiv(-123456789.0, den, FLT_EPSILON, expected);
+    returned         =  MsMath::protectedDiv(-123456789.0, den, static_cast<double>(FLT_EPSILON), expected);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator inside non-default threshold with non-default zero return value
-    den              =  FLT_EPSILON * 0.5;
+    den              =  static_cast<double>(FLT_EPSILON) * 0.5;
     expected         = -1.0;
-    returned         =  MsMath::protectedDiv(987654321.0, den, FLT_EPSILON, expected);
+    returned         =  MsMath::protectedDiv(987654321.0, den, static_cast<double>(FLT_EPSILON), expected);
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator inside negative threshold with default zero return value
-    den              =  FLT_EPSILON * 0.5;
+    den              =  static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  1.0 / den;
-    returned         =  MsMath::protectedDiv(1.0, den, -FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1.0, den, -static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator outside negative threshold with default zero return value
-    den              =  FLT_EPSILON * 2.0;
+    den              =  static_cast<double>(FLT_EPSILON) * 2.0;
     expected         =  1.0 / den;
-    returned         =  MsMath::protectedDiv(1.0, den, -FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1.0, den, -static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for negative denominator inside negative threshold with default zero return value
-    den              = -FLT_EPSILON * 0.5;
+    den              = -static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  1.0 / den;
-    returned         =  MsMath::protectedDiv(1.0, den, -FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1.0, den, -static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     /// @test for positive denominator inside negative threshold with default zero return value
-    den              =  FLT_EPSILON * 0.5;
+    den              =  static_cast<double>(FLT_EPSILON) * 0.5;
     expected         =  1.0 / den;
-    returned         =  MsMath::protectedDiv(1.0, den, -FLT_EPSILON);
+    returned         =  MsMath::protectedDiv(1.0, den, -static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(expected, returned,  m_defaultTolerance);
 
     std::cout << "Pass";

--- a/ms-utils/properties/test/UtFluidProperties.cpp
+++ b/ms-utils/properties/test/UtFluidProperties.cpp
@@ -369,7 +369,7 @@ void UtFluidProperties::testLowP()
         FluidProperties::FluidType type = static_cast<FluidProperties::FluidType>(i);
         for (int j = 0; j < 10; ++j) {
             const double temperature = 270.0;
-            const double expectedP   = FLT_EPSILON + FLT_EPSILON * 0.1 * j;
+            const double expectedP   = static_cast<double>(FLT_EPSILON) + static_cast<double>(FLT_EPSILON) * 0.1 * j;
             const double expectedD   = mArticle->getProperties(type)->
                 getDensity(temperature, expectedP);
             const double returnedP   = mArticle->getProperties(type)->
@@ -387,7 +387,7 @@ void UtFluidProperties::testLowP()
         FluidProperties::FluidType type = static_cast<FluidProperties::FluidType>(i);
         for (int j = 0; j < 10; ++j) {
             const double temperature = 270.0;
-            const double expectedP   = FLT_EPSILON + FLT_EPSILON * 0.1 * j;
+            const double expectedP   = static_cast<double>(FLT_EPSILON) + static_cast<double>(FLT_EPSILON) * 0.1 * j;
             const double expectedD   = mArticle->getProperties(type)->
                 getDensity(temperature, expectedP);
             const double returnedP   = mArticle->getProperties(type)->
@@ -733,16 +733,16 @@ void UtFluidProperties::testHeTable()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_HE_REAL_GAS)->getDensity(2.1768, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(303.4472,
                                  mArticle->getProperties(FluidProperties::GUNNS_HE_REAL_GAS)->getDensity(2.1768, 60000.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_HE_REAL_GAS)->getDensity(1000.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(27.06089,
                                  mArticle->getProperties(FluidProperties::GUNNS_HE_REAL_GAS)->getDensity(1000.0, 60000.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Critical point:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(66.78098,
@@ -792,16 +792,16 @@ void UtFluidProperties::testXeTable()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_XE_REAL_GAS)->getDensity(170.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(3052.36,
                                  mArticle->getProperties(FluidProperties::GUNNS_XE_REAL_GAS)->getDensity(170.0, 34473.8),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_XE_REAL_GAS)->getDensity(750.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(692.003,
                                  mArticle->getProperties(FluidProperties::GUNNS_XE_REAL_GAS)->getDensity(750.0, 34473.8),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Critical point:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1118.36,
@@ -851,16 +851,16 @@ void UtFluidProperties::testN2Table()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_N2_REAL_GAS)->getDensity(160.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(693.263,
                                  mArticle->getProperties(FluidProperties::GUNNS_N2_REAL_GAS)->getDensity(160.0, 59090.9),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_N2_REAL_GAS)->getDensity(750.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(209.91,
                                  mArticle->getProperties(FluidProperties::GUNNS_N2_REAL_GAS)->getDensity(750.0, 59090.9),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Loop across the entire table and check for good inverse between pressure and density
     ///       at all points.
@@ -905,16 +905,16 @@ void UtFluidProperties::testO2Table()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_O2_REAL_GAS)->getDensity(160.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1003.26,
                                  mArticle->getProperties(FluidProperties::GUNNS_O2_REAL_GAS)->getDensity(160.0, 59090.9),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_O2_REAL_GAS)->getDensity(750.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(254.064,
                                  mArticle->getProperties(FluidProperties::GUNNS_O2_REAL_GAS)->getDensity(750.0, 59090.9),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Loop across the entire table and check for good inverse between pressure and density
     ///       at all points.
@@ -959,16 +959,16 @@ void UtFluidProperties::testH2Table()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_H2_REAL_GAS)->getDensity(64.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(88.3871,
                                  mArticle->getProperties(FluidProperties::GUNNS_H2_REAL_GAS)->getDensity(64.0, 80000.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(0.0,
                                  mArticle->getProperties(FluidProperties::GUNNS_H2_REAL_GAS)->getDensity(1000.0, 0.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(16.8613,
                                  mArticle->getProperties(FluidProperties::GUNNS_H2_REAL_GAS)->getDensity(1000.0, 80000.0),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Loop across the entire table and check for good inverse between pressure and density
     ///       at all points.
@@ -1013,16 +1013,16 @@ void UtFluidProperties::testWaterPvtTable()
     /// @test A few specific points for good table data.  Table corners:
     CPPUNIT_ASSERT_DOUBLES_EQUAL(999.792208924,
                                  mArticle->getProperties(FluidProperties::GUNNS_WATER_PVT)->getDensity(273.16, 1.0e-10),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(1000.3387535,
                                  mArticle->getProperties(FluidProperties::GUNNS_WATER_PVT)->getDensity(273.16, 1075.4274162),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(999.792208924,
                                  mArticle->getProperties(FluidProperties::GUNNS_WATER_PVT)->getDensity(373.506467, 1.0e-10),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
     CPPUNIT_ASSERT_DOUBLES_EQUAL(958.549732485,
                                  mArticle->getProperties(FluidProperties::GUNNS_WATER_PVT)->getDensity(373.506467, 1075.4274162),
-                                 FLT_EPSILON);
+                                 static_cast<double>(FLT_EPSILON));
 
     /// @test Loop across the entire table and check for good inverse between pressure and density
     ///       at all points.
@@ -1078,7 +1078,7 @@ void UtFluidProperties::testSaturationCurveConsistency()
         FluidProperties::FluidType type = static_cast<FluidProperties::FluidType>(i);
         const double Ps   = mArticle->getProperties(type)->getSaturationPressure(temperature[i]);
         const double Ts   = mArticle->getProperties(type)->getSaturationTemperature(Ps);
-        CPPUNIT_ASSERT_DOUBLES_EQUAL(temperature[i], Ts, FLT_EPSILON);
+        CPPUNIT_ASSERT_DOUBLES_EQUAL(temperature[i], Ts, static_cast<double>(FLT_EPSILON));
     }
 
     std::cout << "... Pass" << std::endl;

--- a/ms-utils/strings/test/UtStrings.cpp
+++ b/ms-utils/strings/test/UtStrings.cpp
@@ -56,9 +56,9 @@ void UtStrings::testFloatToString()
     std::cout << "-----------------------------------------------------------------------------";
     std::cout << "\n Strings Test 01: testFloatToString ..........................";
 
-    float convert    = 3.14159;
-    float minValue   = 0.0;
-    float maxValue   = 4.0;
+    double convert    = 3.14159;
+    double minValue   = 0.0;
+    double maxValue   = 4.0;
     std::string expected = "3";
     CPPUNIT_ASSERT_EQUAL(expected, Strings::floatToString(convert, 0, minValue, maxValue));
 
@@ -92,9 +92,9 @@ void UtStrings::testIntToString()
 {
     std::cout << "\n Strings Test 01: testIntToString ............................";
 
-    float convert    = 3;
-    float minValue   = 0;
-    float maxValue   = 1234;
+    int convert    = 3;
+    int minValue   = 0;
+    int maxValue   = 1234;
     std::string expected = "3";
     CPPUNIT_ASSERT_EQUAL(expected, Strings::intToString(convert, minValue, maxValue));
 


### PR DESCRIPTION
Another clean-up effort. This should fix all the warnings you get if you compile the unit tests with the -Wdouble-promotion and -Wfloat-conversion flags.