### PR TITLE
Add Argon to the list of Trace Compounds

### DIFF
--- a/ms-utils/properties/ChemicalCompound.cpp
+++ b/ms-utils/properties/ChemicalCompound.cpp
@@ -129,6 +129,7 @@ DefinedChemicalCompounds::DefinedChemicalCompounds()
     mCompoundOH        (ChemicalCompound::OH,         "OH",         FluidProperties::NO_FLUID,  17.0073,  ThermoCoeffHighTempScaleOH,  ThermoCoeffLowTempScaleOH),
     mCompoundO         (ChemicalCompound::O,          "O",          FluidProperties::NO_FLUID,  15.9994,  ThermoCoeffHighTempScaleO,   ThermoCoeffLowTempScaleO),
     mCompoundHe        (ChemicalCompound::He,         "He",         FluidProperties::NO_FLUID,  4.00260,  ThermoCoeffHighTempScaleHe,  ThermoCoeffLowTempScaleHe),
+    mCompoundAr        (ChemicalCompound::Ar,         "Ar",         FluidProperties::NO_FLUID,  39.948,  ThermoCoeffDefaultScale,  ThermoCoeffDefaultScale), // molar weight data from princeton https://www.princeton.edu/~maelabs/mae324/glos324/argon.htm#:~:text=Argon%20is%20an%20inert%20gas,of%201.40%20Mg%2Fm3. Argon is inert and not expected to need thermo coeffs
     mCompounds()
     {
         /// - Load the chemical compounds array with the pointers to the compounds
@@ -161,6 +162,7 @@ DefinedChemicalCompounds::DefinedChemicalCompounds()
         mCompounds[ChemicalCompound::OH]         = &mCompoundOH;
         mCompounds[ChemicalCompound::O]          = &mCompoundO;
         mCompounds[ChemicalCompound::He]         = &mCompoundHe;
+        mCompounds[ChemicalCompound::Ar]         = &mCompoundAr;
     }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/ms-utils/properties/ChemicalCompound.hh
+++ b/ms-utils/properties/ChemicalCompound.hh
@@ -160,7 +160,7 @@ protected:
     ChemicalCompound mCompoundOH;                    /**< (--) OH chemical compound */
     ChemicalCompound mCompoundO;                     /**< (--) O chemical compound */
     ChemicalCompound mCompoundHe;                    /**< (--) He chemical compound */
-    ChemicalCompound mCompoundAr;                    /**< (--) He chemical compound */
+    ChemicalCompound mCompoundAr;                    /**< (--) Ar chemical compound */
     ChemicalCompound* mCompounds[ChemicalCompound::NO_COMPOUND];  /**< (--) Compounds pointer array */
 
     /// --        Arrays to Hold the Thermodynamic Coefficients for each Compound

--- a/ms-utils/properties/ChemicalCompound.hh
+++ b/ms-utils/properties/ChemicalCompound.hh
@@ -29,6 +29,7 @@ ASSUMPTIONS AND LIMITATIONS:
 
  PROGRAMMERS:
 - ((Kenneth McMurtrie) (Tietronix Software) (Initial) (2011-05))
+- ((Maverick Thigpen) (Axiom Space) (2025))
 
 @{
  */
@@ -80,7 +81,8 @@ public:
         OH          = 26, ///<  Hydroxyl
         O           = 27, ///<  Singular Oxygen
         He          = 28, ///<  Helium
-        NO_COMPOUND = 29, ///<  Invalid or number of compounds - Keep this last!
+        Ar          = 29, ///<  Argon
+        NO_COMPOUND = 30, ///<  Invalid or number of compounds - Keep this last!
     };
     const ChemicalCompound::Type     mType;      /**< (--)    Type of this Chemical Compound. */
     const std::string                mName;      /**< (--)    Compound name. */
@@ -158,6 +160,7 @@ protected:
     ChemicalCompound mCompoundOH;                    /**< (--) OH chemical compound */
     ChemicalCompound mCompoundO;                     /**< (--) O chemical compound */
     ChemicalCompound mCompoundHe;                    /**< (--) He chemical compound */
+    ChemicalCompound mCompoundAr;                    /**< (--) He chemical compound */
     ChemicalCompound* mCompounds[ChemicalCompound::NO_COMPOUND];  /**< (--) Compounds pointer array */
 
     /// --        Arrays to Hold the Thermodynamic Coefficients for each Compound


### PR DESCRIPTION
GUNNS does not natively support Argon, so this merge request adds it in. 

For additional context: O2 production commonly leaves some amount of argon in the O2 container. This feature will be useful for future uses involving O2. 