### PR TITLE
Resize UtGunnsFluidSorptionBed::tTcTypes from two entries to three

### DIFF
--- a/aspects/fluid/source/test/UtGunnsFluidSorptionBed.hh
+++ b/aspects/fluid/source/test/UtGunnsFluidSorptionBed.hh
@@ -131,7 +131,7 @@ class UtGunnsFluidSorptionBed: public CppUnit::TestFixture
         double                              tTimeStep;           /**< (s)    Time step. */
         DefinedFluidProperties*             tFluidProperties;    /**< (--)   Predefined fluid properties. */
         DefinedChemicalCompounds*           tCompoundProperties; /**< (--)   Predefined chemical compound properties. */
-        ChemicalCompound::Type              tTcTypes[2];         /**< (--)   Trace compounds config data for nodes. */
+        ChemicalCompound::Type              tTcTypes[3];         /**< (--)   Trace compounds config data for nodes. */
         GunnsFluidTraceCompoundsConfigData* tFluidTcConfig;      /**< (--)   Trace compounds config data for nodes. */
         PolyFluidConfigData*                tFluidConfig;        /**< (--)   Fluid config data. */
         GunnsFluidTraceCompoundsInputData*  tFluidTcInput;       /**< (--)   Trace compounds input data for nodes. */


### PR DESCRIPTION
The sorption bed test fixture writes past its trace compound type array. `UtGunnsFluidSorptionBed` declares `tTcTypes` with two elements, while `setUp` writes indices zero through two and configures three trace compounds. The third write corrupts adjacent fixture state, but the likely adjacent state is immediately overwritten before use, so this is probably harmless.

Resize `UtGunnsFluidSorptionBed::tTcTypes` from two entries to three.
